### PR TITLE
feat(core): add business-use scan CLI for static SDK extraction

### DIFF
--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -48,12 +48,23 @@ Repository = "https://github.com/desplega-ai/business-use"
 Issues = "https://github.com/desplega-ai/business-use/issues"
 Changelog = "https://github.com/desplega-ai/business-use/releases"
 
+[project.optional-dependencies]
+scan = [
+    "tree-sitter>=0.25.0",
+    "tree-sitter-javascript>=0.25.0",
+    "tree-sitter-typescript>=0.23.0",
+]
+
 [dependency-groups]
 dev = [
     "ruff>=0.8.0",
     "mypy>=1.13.0",
     "pytest>=8.0.0",
+    "pytest-asyncio>=0.24.0",
     "types-pyyaml>=6.0.12.20250915",
+    "tree-sitter>=0.25.0",
+    "tree-sitter-javascript>=0.25.0",
+    "tree-sitter-typescript>=0.23.0",
 ]
 
 [build-system]

--- a/core/src/api/api.py
+++ b/core/src/api/api.py
@@ -17,6 +17,8 @@ from src.api.models import (
     EventBatchItem,
     NodeCreateSchema,
     NodeUpdateSchema,
+    ScanUploadPayload,
+    ScanUploadResponse,
     SuccessResponse,
 )
 from src.db.transactional import transactional
@@ -432,6 +434,86 @@ async def delete_definition(
         await s.merge(md)
 
     return SuccessResponse(message="Node deleted")
+
+
+@router.post("/nodes/scan")
+async def upload_scan(
+    _: Annotated[None, Depends(ensure_api_key)],
+    body: ScanUploadPayload,
+):
+    """Batch upsert nodes from scanner output.
+
+    Accepts the scanner CLI output and upserts nodes with source="scan".
+    Nodes that existed with source="scan" but are no longer in the payload
+    are soft-deleted.
+    """
+    created = 0
+    updated = 0
+    deleted = 0
+
+    async with transactional() as s:
+        # Collect all node IDs from the payload, grouped by flow
+        payload_node_ids_by_flow: dict[str, set[str]] = {}
+
+        for flow_name, scanned_nodes in body.flows.items():
+            payload_node_ids_by_flow[flow_name] = set()
+
+            for body_node in scanned_nodes:
+                payload_node_ids_by_flow[flow_name].add(body_node.id)
+
+                existing_node = await s.get(Node, body_node.id)
+
+                if existing_node:
+                    # Update existing node
+                    existing_node.flow = body_node.flow
+                    existing_node.type = body_node.type
+                    existing_node.source = "scan"
+                    existing_node.description = body_node.description
+                    existing_node.dep_ids = body_node.dep_ids
+                    existing_node.conditions = body_node.conditions
+                    existing_node.updated_at = now()
+                    existing_node.deleted_at = None
+                    await s.merge(existing_node)
+                    updated += 1
+                else:
+                    # Create new node
+                    node = Node(
+                        id=body_node.id,
+                        flow=body_node.flow,
+                        type=body_node.type,
+                        source="scan",
+                        description=body_node.description,
+                        dep_ids=body_node.dep_ids,
+                        conditions=body_node.conditions,
+                        created_at=now(),
+                        status="active",
+                    )
+                    s.add(node)
+                    created += 1
+
+        # Soft-delete stale scan nodes per flow
+        for flow_name, payload_ids in payload_node_ids_by_flow.items():
+            stmt = select(Node).where(
+                Node.flow == flow_name,
+                Node.source == "scan",
+                Node.deleted_at.is_(None),  # type: ignore
+            )
+            result = await s.execute(stmt)
+            existing_scan_nodes = result.scalars().all()
+
+            for node in existing_scan_nodes:
+                if node.id not in payload_ids:
+                    node.deleted_at = now()
+                    node.updated_at = now()
+                    await s.merge(node)
+                    deleted += 1
+
+    return ScanUploadResponse(
+        created=created,
+        updated=updated,
+        deleted=deleted,
+        flows=list(body.flows.keys()),
+    )
 
 
 @asynccontextmanager

--- a/core/src/api/models.py
+++ b/core/src/api/models.py
@@ -86,3 +86,40 @@ class EvalInput(BaseModel):
     run_id: str
     flow: str
     start_node_id: str | None = None
+
+
+# --- Scanner models ---
+
+
+class ScannedNode(BaseModel):
+    """A node extracted by the scanner."""
+
+    id: str
+    flow: str
+    type: Literal["act", "assert"]
+    dep_ids: list[str] = []
+    description: str | None = None
+    conditions: list[NodeCondition] = []
+    has_filter: bool = False
+    has_validator: bool = False
+    source_file: str | None = None
+    source_line: int | None = None
+    source_column: int | None = None
+
+
+class ScanUploadPayload(BaseModel):
+    """Payload from the scanner CLI."""
+
+    version: str = "1.0"
+    scanned_at: str
+    files_scanned: int
+    flows: dict[str, list[ScannedNode]]
+
+
+class ScanUploadResponse(BaseModel):
+    """Response from the scan upload endpoint."""
+
+    created: int
+    updated: int
+    deleted: int
+    flows: list[str]

--- a/core/src/cli.py
+++ b/core/src/cli.py
@@ -1987,6 +1987,133 @@ def validate(path: Path | None) -> None:
         raise click.Abort() from e
 
 
+@cli.command()
+@click.argument("path", type=click.Path(exists=True, path_type=Path))
+@click.option(
+    "--dry-run", is_flag=True, help="Scan and print results without pushing to backend"
+)
+@click.option(
+    "--format",
+    "output_format",
+    type=click.Choice(["json", "table"]),
+    default="json",
+    help="Output format for dry-run",
+)
+@click.option("--validate", is_flag=True, help="Run graph validation checks")
+@click.option("--flow", "flow_filter", help="Filter results to a specific flow")
+@click.option("--url", envvar="BUSINESS_USE_URL", help="Backend API URL")
+@click.option("--api-key", envvar="BUSINESS_USE_API_KEY", help="Backend API key")
+def scan(
+    path: Path,
+    dry_run: bool,
+    output_format: str,
+    validate: bool,
+    flow_filter: str | None,
+    url: str | None,
+    api_key: str | None,
+) -> None:
+    """Scan JS/TS source files to extract Business-Use SDK call sites.
+
+    PATH is a file or directory to scan for ensure() calls.
+
+    Examples:
+
+        business-use scan src/ --dry-run
+
+        business-use scan src/ --dry-run --format table
+
+        business-use scan src/ --validate
+
+        business-use scan src/ --dry-run --flow checkout
+    """
+    from src.scanner import scan_directory, scan_files, validate_graph
+    from src.scanner.formatters import format_json, format_table
+
+    target = Path(path)
+
+    if target.is_dir():
+        result = scan_directory(target)
+    else:
+        result = scan_files([target])
+
+    # Apply flow filter
+    if flow_filter:
+        if flow_filter in result.flows:
+            result.flows = {flow_filter: result.flows[flow_filter]}
+        else:
+            result.flows = {}
+
+    if dry_run:
+        if output_format == "table":
+            click.echo(format_table(result))
+        else:
+            click.echo(format_json(result))
+        return
+
+    if validate:
+        validation_warnings = validate_graph(result.flows)
+        all_warnings = result.warnings + validation_warnings
+        if all_warnings:
+            click.secho(
+                f"Validation found {len(all_warnings)} warning(s):", fg="yellow"
+            )
+            for w in all_warnings:
+                loc = f"{w.file}:{w.line}" if w.line is not None else w.file
+                click.echo(f"  \u26a0 {loc} - {w.message}")
+        else:
+            click.secho("Validation passed - no warnings.", fg="green")
+        total_nodes = sum(len(nodes) for nodes in result.flows.values())
+        click.echo(
+            f"Scanned {result.files_scanned} files, "
+            f"found {len(result.flows)} flow(s) with {total_nodes} node(s)."
+        )
+        return
+
+    # Push mode: require url and api_key
+    if not url:
+        click.secho("Error: --url or BUSINESS_USE_URL is required.", fg="red", err=True)
+        raise click.Abort()
+    if not api_key:
+        click.secho(
+            "Error: --api-key or BUSINESS_USE_API_KEY is required.",
+            fg="red",
+            err=True,
+        )
+        raise click.Abort()
+
+    from src.scanner.api_client import ScanPushError, push_scan_result
+
+    # Run validation before push
+    validation_warnings = validate_graph(result.flows)
+    if validation_warnings:
+        click.secho(
+            f"Warning: {len(validation_warnings)} validation warning(s):",
+            fg="yellow",
+        )
+        for w in validation_warnings:
+            loc = f"{w.file}:{w.line}" if w.line is not None else w.file
+            click.echo(f"  \u26a0 {loc} - {w.message}")
+
+    total_nodes = sum(len(nodes) for nodes in result.flows.values())
+    click.echo(
+        f"Pushing {total_nodes} node(s) across {len(result.flows)} flow(s) to {url}..."
+    )
+
+    try:
+        resp = push_scan_result(result, url, api_key)
+    except ScanPushError as e:
+        click.secho(f"Error: {e}", fg="red", err=True)
+        raise SystemExit(1) from None
+
+    click.secho(
+        f"Pushed {total_nodes} nodes across {len(result.flows)} flow(s) "
+        f"(created: {resp.get('created', 0)}, "
+        f"updated: {resp.get('updated', 0)}, "
+        f"deleted: {resp.get('deleted', 0)})",
+        fg="green",
+    )
+
+
 def main() -> None:
     """Entry point for the CLI."""
     log.info("CLI is running")

--- a/core/src/models.py
+++ b/core/src/models.py
@@ -68,6 +68,7 @@ NodeType = Literal[
 NodeSource = Literal[
     "code",
     "manual",
+    "scan",
 ]
 
 ActionType = Literal[

--- a/core/src/scanner/__init__.py
+++ b/core/src/scanner/__init__.py
@@ -1,0 +1,60 @@
+"""Scanner module: statically analyze JS/TS codebases to extract SDK call sites."""
+
+from pathlib import Path
+
+from src.scanner.models import ExtractedNode, ScanResult, ScanWarning
+from src.scanner.parser import SCAN_EXTENSIONS, _check_tree_sitter
+from src.scanner.validator import validate_graph
+
+__all__ = [
+    "ExtractedNode",
+    "ScanResult",
+    "ScanWarning",
+    "scan_directory",
+    "scan_files",
+    "validate_graph",
+]
+
+
+def scan_files(paths: list[Path]) -> ScanResult:
+    """Scan specific JS/TS files for SDK calls."""
+    _check_tree_sitter()
+    from src.scanner.extractor import scan_file
+
+    result = ScanResult()
+
+    for path in paths:
+        filepath = str(path)
+        result.files_scanned += 1
+
+        nodes, warnings, skipped = scan_file(filepath)
+        if skipped:
+            result.files_skipped += 1
+            continue
+
+        result.warnings.extend(warnings)
+        for node in nodes:
+            if node.flow not in result.flows:
+                result.flows[node.flow] = []
+            result.flows[node.flow].append(node)
+
+    return result
+
+
+def scan_directory(
+    path: Path,
+    include: list[str] | None = None,
+    exclude: list[str] | None = None,
+) -> ScanResult:
+    """Scan a directory for JS/TS files containing SDK calls."""
+    _check_tree_sitter()
+
+    exclude = exclude or ["node_modules"]
+    allowed_extensions = set(include) if include else SCAN_EXTENSIONS
+    files = sorted(
+        p
+        for p in path.rglob("*")
+        if p.suffix in allowed_extensions and not any(ex in str(p) for ex in exclude)
+    )
+
+    return scan_files(files)

--- a/core/src/scanner/api_client.py
+++ b/core/src/scanner/api_client.py
@@ -1,5 +1,7 @@
 """API client for pushing scan results to the backend."""
 
+from typing import Any
+
 import httpx
 
 from src.scanner.models import ScanResult
@@ -9,9 +11,9 @@ class ScanPushError(Exception):
     """Error pushing scan results to the API."""
 
 
-def _build_payload(result: ScanResult) -> dict:
+def _build_payload(result: ScanResult) -> dict[str, Any]:
     """Convert ScanResult to the ScanUploadPayload JSON format."""
-    flows: dict[str, list[dict]] = {}
+    flows: dict[str, list[dict[str, Any]]] = {}
     for flow_name, nodes in result.flows.items():
         flows[flow_name] = [
             {
@@ -43,7 +45,7 @@ def push_scan_result(
     url: str,
     api_key: str,
     timeout: float = 30.0,
-) -> dict:
+) -> dict[str, Any]:
     """Push scan results to the backend API.
 
     Returns:
@@ -79,4 +81,5 @@ def push_scan_result(
     if response.status_code >= 400:
         raise ScanPushError(f"Client error ({response.status_code}): {response.text}")
 
-    return response.json()
+    resp_data: dict[str, Any] = response.json()
+    return resp_data

--- a/core/src/scanner/api_client.py
+++ b/core/src/scanner/api_client.py
@@ -1,0 +1,82 @@
+"""API client for pushing scan results to the backend."""
+
+import httpx
+
+from src.scanner.models import ScanResult
+
+
+class ScanPushError(Exception):
+    """Error pushing scan results to the API."""
+
+
+def _build_payload(result: ScanResult) -> dict:
+    """Convert ScanResult to the ScanUploadPayload JSON format."""
+    flows: dict[str, list[dict]] = {}
+    for flow_name, nodes in result.flows.items():
+        flows[flow_name] = [
+            {
+                "id": n.id,
+                "flow": n.flow,
+                "type": n.type,
+                "dep_ids": n.dep_ids,
+                "description": n.description,
+                "conditions": n.conditions,
+                "has_filter": n.has_filter,
+                "has_validator": n.has_validator,
+                "source_file": n.source_file,
+                "source_line": n.source_line,
+                "source_column": n.source_column,
+            }
+            for n in nodes
+        ]
+
+    return {
+        "version": result.version,
+        "scanned_at": result.scanned_at,
+        "files_scanned": result.files_scanned,
+        "flows": flows,
+    }
+
+
+def push_scan_result(
+    result: ScanResult,
+    url: str,
+    api_key: str,
+    timeout: float = 30.0,
+) -> dict:
+    """Push scan results to the backend API.
+
+    Returns:
+        API response dict with created/updated/deleted counts.
+
+    Raises:
+        ScanPushError: On any API or connection error.
+    """
+    endpoint = f"{url.rstrip('/')}/v1/nodes/scan"
+    payload = _build_payload(result)
+
+    try:
+        response = httpx.post(
+            endpoint,
+            json=payload,
+            headers={
+                "X-Api-Key": api_key,
+                "Content-Type": "application/json",
+            },
+            timeout=timeout,
+        )
+    except httpx.ConnectError:
+        raise ScanPushError(f"Connection refused: {url}") from None
+    except httpx.TimeoutException:
+        raise ScanPushError(f"Request timed out after {timeout}s") from None
+    except httpx.HTTPError as e:
+        raise ScanPushError(f"HTTP error: {e}") from e
+
+    if response.status_code == 401:
+        raise ScanPushError("Authentication failed: invalid API key")
+    if response.status_code >= 500:
+        raise ScanPushError(f"Server error ({response.status_code}): {response.text}")
+    if response.status_code >= 400:
+        raise ScanPushError(f"Client error ({response.status_code}): {response.text}")
+
+    return response.json()

--- a/core/src/scanner/extractor.py
+++ b/core/src/scanner/extractor.py
@@ -1,0 +1,250 @@
+"""Node extraction from JS/TS AST: find SDK call sites and extract properties."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from src.scanner.imports import (
+    TARGET_FUNCTIONS,
+    ImportInfo,
+    _get_string_value,
+    _walk,
+    extract_imports,
+)
+from src.scanner.models import ExtractedNode, ScanWarning
+from src.scanner.parser import parse_file
+
+if TYPE_CHECKING:
+    from tree_sitter import Node
+
+
+def _is_target_call(node: Node, imports: ImportInfo) -> str | None:
+    """Check if a call_expression is a target SDK call.
+
+    Returns the canonical function name (ensure/act/assert) or None.
+    """
+    fn_node = node.child_by_field_name("function")
+    if not fn_node:
+        return None
+
+    # Direct call: ensure({...})
+    if fn_node.type == "identifier":
+        name = fn_node.text.decode("utf-8")
+        if name in imports.named:
+            return name
+        if name in imports.aliases:
+            return imports.aliases[name]
+        return None
+
+    # Member expression: bu.ensure({...})
+    if fn_node.type == "member_expression":
+        obj = fn_node.child_by_field_name("object")
+        prop = fn_node.child_by_field_name("property")
+        if (
+            obj
+            and prop
+            and obj.type == "identifier"
+            and prop.type == "property_identifier"
+        ):
+            obj_name = obj.text.decode("utf-8")
+            prop_name = prop.text.decode("utf-8")
+            if obj_name == imports.namespace and prop_name in TARGET_FUNCTIONS:
+                return prop_name
+
+    return None
+
+
+def _extract_object_props(obj_node: Node) -> dict:
+    """Extract properties from an object literal argument."""
+    result: dict = {
+        "id": None,
+        "flow": None,
+        "dep_ids": [],
+        "has_validator": False,
+        "has_filter": False,
+        "description": None,
+        "conditions": [],
+        "warnings": [],
+    }
+
+    for child in obj_node.children:
+        if child.type != "pair":
+            continue
+
+        key_node = child.child_by_field_name("key")
+        value_node = child.child_by_field_name("value")
+        if not key_node or not value_node:
+            continue
+
+        key = key_node.text.decode("utf-8")
+
+        if key == "id":
+            val = _get_string_value(value_node)
+            if val is not None:
+                result["id"] = val
+            else:
+                result["warnings"].append(
+                    f"'id' is not a string literal ({value_node.type})"
+                )
+
+        elif key == "flow":
+            val = _get_string_value(value_node)
+            if val is not None:
+                result["flow"] = val
+            else:
+                result["warnings"].append(
+                    f"'flow' is not a string literal ({value_node.type})"
+                )
+
+        elif key in ("depIds", "dep_ids"):
+            if value_node.type == "array":
+                for elem in value_node.children:
+                    if elem.type in ("string", "template_string"):
+                        val = _get_string_value(elem)
+                        if val is not None:
+                            result["dep_ids"].append(val)
+                        else:
+                            result["warnings"].append(
+                                "depIds contains non-extractable element"
+                            )
+                    elif elem.type == "identifier":
+                        result["warnings"].append(
+                            f"depIds contains variable '{elem.text.decode()}'"
+                        )
+                    elif elem.type == "spread_element":
+                        result["warnings"].append("depIds contains spread element")
+            else:
+                result["warnings"].append(
+                    f"depIds is not an array literal ({value_node.type})"
+                )
+
+        elif key == "validator":
+            result["has_validator"] = True
+
+        elif key == "filter":
+            result["has_filter"] = True
+
+        elif key == "description":
+            val = _get_string_value(value_node)
+            if val is not None:
+                result["description"] = val
+
+        elif key == "conditions":
+            if value_node.type == "array":
+                for elem in value_node.children:
+                    if elem.type == "object":
+                        for pair in elem.children:
+                            if pair.type == "pair":
+                                pk = pair.child_by_field_name("key")
+                                pv = pair.child_by_field_name("value")
+                                if pk and pv and pk.text == b"timeout_ms":
+                                    if pv.type == "number":
+                                        result["conditions"].append(
+                                            {"timeout_ms": int(pv.text.decode())}
+                                        )
+
+    return result
+
+
+def scan_file(filepath: str) -> tuple[list[ExtractedNode], list[ScanWarning], bool]:
+    """Scan a single JS/TS file for SDK calls.
+
+    Returns:
+        Tuple of (extracted_nodes, warnings, was_skipped).
+        was_skipped is True if the file had no business-use imports.
+    """
+    tree = parse_file(filepath)
+    root = tree.root_node
+
+    # Step 1: Check imports
+    imports = extract_imports(root)
+    if not imports.has_imports:
+        return [], [], True
+
+    # Step 2: Find all call expressions
+    nodes: list[ExtractedNode] = []
+    warnings: list[ScanWarning] = []
+
+    for node in _walk(root):
+        if node.type != "call_expression":
+            continue
+
+        fn_name = _is_target_call(node, imports)
+        if fn_name is None:
+            continue
+
+        # Get the first argument (object literal)
+        args_node = node.child_by_field_name("arguments")
+        if not args_node:
+            continue
+
+        # Find first object argument
+        obj_node = None
+        for arg_child in args_node.children:
+            if arg_child.type == "object":
+                obj_node = arg_child
+                break
+
+        if not obj_node:
+            warnings.append(
+                ScanWarning(
+                    file=filepath,
+                    line=node.start_point[0] + 1,
+                    message=f"{fn_name}() called without object literal argument",
+                )
+            )
+            continue
+
+        props = _extract_object_props(obj_node)
+
+        if not props["id"] or not props["flow"]:
+            parts = []
+            if not props["id"]:
+                parts.append("missing/non-literal 'id'")
+            if not props["flow"]:
+                parts.append("missing/non-literal 'flow'")
+            warnings.append(
+                ScanWarning(
+                    file=filepath,
+                    line=node.start_point[0] + 1,
+                    message=f"{fn_name}() skipped: {', '.join(parts)}",
+                )
+            )
+            continue
+
+        # Determine type
+        if fn_name == "assert":
+            node_type = "assert"
+        elif fn_name == "act":
+            node_type = "act"
+        else:  # ensure
+            node_type = "assert" if props["has_validator"] else "act"
+
+        extracted = ExtractedNode(
+            id=props["id"],
+            flow=props["flow"],
+            type=node_type,
+            dep_ids=props["dep_ids"],
+            has_validator=props["has_validator"],
+            has_filter=props["has_filter"],
+            description=props["description"],
+            conditions=props["conditions"],
+            source_file=filepath,
+            source_line=node.start_point[0] + 1,
+            source_column=node.start_point[1] + 1,
+            warnings=props["warnings"],
+        )
+
+        # Propagate property-level warnings
+        for w in props["warnings"]:
+            warnings.append(
+                ScanWarning(
+                    file=filepath,
+                    line=node.start_point[0] + 1,
+                    message=w,
+                )
+            )
+
+        nodes.append(extracted)
+
+    return nodes, warnings, False

--- a/core/src/scanner/extractor.py
+++ b/core/src/scanner/extractor.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from src.scanner.imports import (
     TARGET_FUNCTIONS,
@@ -28,7 +28,7 @@ def _is_target_call(node: Node, imports: ImportInfo) -> str | None:
         return None
 
     # Direct call: ensure({...})
-    if fn_node.type == "identifier":
+    if fn_node.type == "identifier" and fn_node.text is not None:
         name = fn_node.text.decode("utf-8")
         if name in imports.named:
             return name
@@ -46,17 +46,17 @@ def _is_target_call(node: Node, imports: ImportInfo) -> str | None:
             and obj.type == "identifier"
             and prop.type == "property_identifier"
         ):
-            obj_name = obj.text.decode("utf-8")
-            prop_name = prop.text.decode("utf-8")
+            obj_name = obj.text.decode("utf-8") if obj.text else ""
+            prop_name = prop.text.decode("utf-8") if prop.text else ""
             if obj_name == imports.namespace and prop_name in TARGET_FUNCTIONS:
                 return prop_name
 
     return None
 
 
-def _extract_object_props(obj_node: Node) -> dict:
+def _extract_object_props(obj_node: Node) -> dict[str, Any]:
     """Extract properties from an object literal argument."""
-    result: dict = {
+    result: dict[str, Any] = {
         "id": None,
         "flow": None,
         "dep_ids": [],
@@ -76,7 +76,7 @@ def _extract_object_props(obj_node: Node) -> dict:
         if not key_node or not value_node:
             continue
 
-        key = key_node.text.decode("utf-8")
+        key = key_node.text.decode("utf-8") if key_node.text else ""
 
         if key == "id":
             val = _get_string_value(value_node)
@@ -108,8 +108,9 @@ def _extract_object_props(obj_node: Node) -> dict:
                                 "depIds contains non-extractable element"
                             )
                     elif elem.type == "identifier":
+                        elem_text = elem.text.decode() if elem.text else "?"
                         result["warnings"].append(
-                            f"depIds contains variable '{elem.text.decode()}'"
+                            f"depIds contains variable '{elem_text}'"
                         )
                     elif elem.type == "spread_element":
                         result["warnings"].append("depIds contains spread element")
@@ -138,7 +139,7 @@ def _extract_object_props(obj_node: Node) -> dict:
                                 pk = pair.child_by_field_name("key")
                                 pv = pair.child_by_field_name("value")
                                 if pk and pv and pk.text == b"timeout_ms":
-                                    if pv.type == "number":
+                                    if pv.type == "number" and pv.text is not None:
                                         result["conditions"].append(
                                             {"timeout_ms": int(pv.text.decode())}
                                         )

--- a/core/src/scanner/formatters.py
+++ b/core/src/scanner/formatters.py
@@ -1,0 +1,76 @@
+"""Output formatters for scan results."""
+
+import json
+from dataclasses import asdict
+
+from src.scanner.models import ScanResult, ScanWarning
+
+
+def format_json(result: ScanResult) -> str:
+    """Serialize a ScanResult to a JSON string."""
+    return json.dumps(asdict(result), indent=2)
+
+
+def _fmt_row(cells: tuple[str, ...], col_widths: list[int]) -> str:
+    parts = []
+    for i, cell in enumerate(cells):
+        parts.append(f" {cell:<{col_widths[i] - 1}}")
+    return "\u2502" + "\u2502".join(parts) + "\u2502"
+
+
+def _border(left: str, mid: str, right: str, col_widths: list[int]) -> str:
+    return left + mid.join("\u2500" * w for w in col_widths) + right
+
+
+def format_table(result: ScanResult) -> str:
+    """Render a ScanResult as a human-readable table."""
+    lines: list[str] = []
+
+    if not result.flows:
+        lines.append("No flows found.")
+        _append_warnings(lines, result.warnings)
+        return "\n".join(lines)
+
+    for flow_name, nodes in sorted(result.flows.items()):
+        lines.append(f"Flow: {flow_name} ({len(nodes)} nodes)")
+
+        # Compute column widths
+        headers = ("ID", "Type", "Dep IDs", "Source")
+        rows: list[tuple[str, str, str, str]] = []
+        for node in nodes:
+            dep_ids_str = ", ".join(node.dep_ids) if node.dep_ids else "\u2014"
+            source = (
+                f"{node.source_file}:{node.source_line}"
+                if node.source_file
+                else "\u2014"
+            )
+            rows.append((node.id, node.type, dep_ids_str, source))
+
+        col_widths = [len(h) for h in headers]
+        for row in rows:
+            for i, cell in enumerate(row):
+                col_widths[i] = max(col_widths[i], len(cell))
+
+        # Add padding
+        col_widths = [w + 2 for w in col_widths]
+
+        lines.append(_border("\u250c", "\u252c", "\u2510", col_widths))
+        lines.append(_fmt_row(headers, col_widths))
+        lines.append(_border("\u251c", "\u253c", "\u2524", col_widths))
+        for row in rows:
+            lines.append(_fmt_row(row, col_widths))
+        lines.append(_border("\u2514", "\u2534", "\u2518", col_widths))
+        lines.append("")
+
+    _append_warnings(lines, result.warnings)
+    return "\n".join(lines)
+
+
+def _append_warnings(lines: list[str], warnings: list[ScanWarning]) -> None:
+    """Append formatted warnings to the output lines."""
+    if not warnings:
+        return
+    lines.append(f"Warnings ({len(warnings)}):")
+    for w in warnings:
+        loc = f"{w.file}:{w.line}" if w.line is not None else w.file
+        lines.append(f"  \u26a0 {loc} - {w.message}")

--- a/core/src/scanner/imports.py
+++ b/core/src/scanner/imports.py
@@ -1,0 +1,82 @@
+"""Import analysis: detect business-use SDK imports in JS/TS files."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from tree_sitter import Node
+
+TARGET_FUNCTIONS = {"ensure", "act", "assert"}
+TARGET_MODULES = {"business-use", "business_use", "@desplega.ai/business-use"}
+
+
+def _walk(node: Node):
+    """Yield all descendants of a node."""
+    for child in node.children:
+        yield child
+        yield from _walk(child)
+
+
+def _get_string_value(node: Node) -> str | None:
+    """Extract string value from a string node (handles quotes)."""
+    if node.type == "string":
+        for child in node.children:
+            if child.type == "string_fragment":
+                return child.text.decode("utf-8")
+        return ""
+    if node.type == "template_string":
+        fragments = [c for c in node.children if c.type == "string_fragment"]
+        substitutions = [c for c in node.children if c.type == "template_substitution"]
+        if not substitutions and fragments:
+            return fragments[0].text.decode("utf-8")
+    return None
+
+
+class ImportInfo:
+    """Information about business-use SDK imports found in a file."""
+
+    def __init__(self) -> None:
+        self.named: set[str] = set()
+        self.aliases: dict[str, str] = {}  # local_name -> original_name
+        self.namespace: str | None = None
+
+    @property
+    def has_imports(self) -> bool:
+        return bool(self.named or self.aliases or self.namespace)
+
+
+def extract_imports(root: Node) -> ImportInfo:
+    """Find imports from business-use and return info about what was imported."""
+    result = ImportInfo()
+
+    for node in root.children:
+        if node.type != "import_statement":
+            continue
+
+        source_node = node.child_by_field_name("source")
+        if not source_node:
+            continue
+        module_name = _get_string_value(source_node)
+        if module_name not in TARGET_MODULES:
+            continue
+
+        for child in _walk(node):
+            if child.type == "import_specifier":
+                name_node = child.child_by_field_name("name")
+                alias_node = child.child_by_field_name("alias")
+                if name_node:
+                    original = name_node.text.decode("utf-8")
+                    if original in TARGET_FUNCTIONS:
+                        if alias_node:
+                            local = alias_node.text.decode("utf-8")
+                            result.aliases[local] = original
+                        else:
+                            result.named.add(original)
+
+            if child.type == "namespace_import":
+                for c in child.children:
+                    if c.type == "identifier":
+                        result.namespace = c.text.decode("utf-8")
+
+    return result

--- a/core/src/scanner/imports.py
+++ b/core/src/scanner/imports.py
@@ -22,13 +22,13 @@ def _get_string_value(node: Node) -> str | None:
     """Extract string value from a string node (handles quotes)."""
     if node.type == "string":
         for child in node.children:
-            if child.type == "string_fragment":
+            if child.type == "string_fragment" and child.text is not None:
                 return child.text.decode("utf-8")
         return ""
     if node.type == "template_string":
         fragments = [c for c in node.children if c.type == "string_fragment"]
         substitutions = [c for c in node.children if c.type == "template_substitution"]
-        if not substitutions and fragments:
+        if not substitutions and fragments and fragments[0].text is not None:
             return fragments[0].text.decode("utf-8")
     return None
 
@@ -65,10 +65,10 @@ def extract_imports(root: Node) -> ImportInfo:
             if child.type == "import_specifier":
                 name_node = child.child_by_field_name("name")
                 alias_node = child.child_by_field_name("alias")
-                if name_node:
+                if name_node and name_node.text is not None:
                     original = name_node.text.decode("utf-8")
                     if original in TARGET_FUNCTIONS:
-                        if alias_node:
+                        if alias_node and alias_node.text is not None:
                             local = alias_node.text.decode("utf-8")
                             result.aliases[local] = original
                         else:
@@ -76,7 +76,7 @@ def extract_imports(root: Node) -> ImportInfo:
 
             if child.type == "namespace_import":
                 for c in child.children:
-                    if c.type == "identifier":
+                    if c.type == "identifier" and c.text is not None:
                         result.namespace = c.text.decode("utf-8")
 
     return result

--- a/core/src/scanner/models.py
+++ b/core/src/scanner/models.py
@@ -1,0 +1,43 @@
+"""Scanner-specific types for extracted nodes and scan results."""
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+
+
+@dataclass
+class ScanWarning:
+    """A warning produced during scanning."""
+
+    file: str
+    line: int | None
+    message: str
+
+
+@dataclass
+class ExtractedNode:
+    """A node extracted from a source file."""
+
+    id: str
+    flow: str
+    type: str  # "act" or "assert"
+    dep_ids: list[str] = field(default_factory=list)
+    has_validator: bool = False
+    has_filter: bool = False
+    description: str | None = None
+    conditions: list[dict[str, int]] = field(default_factory=list)
+    source_file: str = ""
+    source_line: int = 0
+    source_column: int = 0
+    warnings: list[str] = field(default_factory=list)
+
+
+@dataclass
+class ScanResult:
+    """Result of scanning a set of files."""
+
+    version: str = "1.0"
+    scanned_at: str = field(default_factory=lambda: datetime.now(UTC).isoformat())
+    files_scanned: int = 0
+    files_skipped: int = 0
+    flows: dict[str, list[ExtractedNode]] = field(default_factory=dict)
+    warnings: list[ScanWarning] = field(default_factory=list)

--- a/core/src/scanner/parser.py
+++ b/core/src/scanner/parser.py
@@ -1,0 +1,51 @@
+"""Tree-sitter parsing: language detection and AST construction."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from tree_sitter import Language, Tree
+
+
+def _check_tree_sitter() -> None:
+    """Check that tree-sitter dependencies are installed."""
+    try:
+        import tree_sitter  # noqa: F401
+        import tree_sitter_javascript  # noqa: F401
+        import tree_sitter_typescript  # noqa: F401
+    except ImportError as e:
+        raise SystemExit(
+            "Scanner requires tree-sitter dependencies.\n"
+            "Install with: pip install 'business-use-core[scan]'\n"
+            "Or with uvx: uvx --with 'business-use-core[scan]' business-use-core scan ..."
+        ) from e
+
+
+def get_language(filepath: str) -> Language:
+    """Get the tree-sitter Language for a file based on its extension."""
+    import tree_sitter_javascript as tsjs
+    import tree_sitter_typescript as tsts
+    from tree_sitter import Language
+
+    ext = Path(filepath).suffix
+    if ext == ".tsx":
+        return Language(tsts.language_tsx())
+    if ext in (".ts", ".mts"):
+        return Language(tsts.language_typescript())
+    return Language(tsjs.language())  # .js, .jsx, .mjs
+
+
+def parse_file(filepath: str) -> Tree:
+    """Parse a JS/TS file and return the tree-sitter Tree."""
+    from tree_sitter import Parser
+
+    source = Path(filepath).read_bytes()
+    lang = get_language(filepath)
+    parser = Parser(lang)
+    return parser.parse(source)
+
+
+# Supported file extensions for scanning
+SCAN_EXTENSIONS = {".ts", ".tsx", ".js", ".jsx", ".mts", ".mjs"}

--- a/core/src/scanner/validator.py
+++ b/core/src/scanner/validator.py
@@ -1,0 +1,90 @@
+"""Graph validation: check dep_ids references, duplicates, unreachable nodes."""
+
+from src.scanner.models import ExtractedNode, ScanWarning
+
+
+def validate_graph(
+    flows: dict[str, list[ExtractedNode]],
+) -> list[ScanWarning]:
+    """Validate the graph structure of extracted nodes.
+
+    Checks:
+    - All dep_ids reference existing nodes within the same flow
+    - No duplicate node IDs within a flow
+    - Unreachable nodes (no path from a root node)
+    """
+    warnings: list[ScanWarning] = []
+
+    for flow_name, nodes in flows.items():
+        node_ids = {n.id for n in nodes}
+        node_map = {n.id: n for n in nodes}
+
+        # Check for duplicate IDs
+        seen: set[str] = set()
+        for node in nodes:
+            if node.id in seen:
+                warnings.append(
+                    ScanWarning(
+                        file=node.source_file,
+                        line=node.source_line,
+                        message=f"Duplicate node ID '{node.id}' in flow '{flow_name}'",
+                    )
+                )
+            seen.add(node.id)
+
+        # Check dep_ids references
+        for node in nodes:
+            for dep_id in node.dep_ids:
+                if dep_id not in node_ids:
+                    warnings.append(
+                        ScanWarning(
+                            file=node.source_file,
+                            line=node.source_line,
+                            message=f"Node '{node.id}' references unknown dep_id '{dep_id}' in flow '{flow_name}'",
+                        )
+                    )
+
+        # Check for unreachable nodes
+        # Root nodes have no dep_ids. Walk from roots via reverse edges.
+        roots = {n.id for n in nodes if not n.dep_ids}
+        if not roots and nodes:
+            # All nodes have deps — everything is unreachable from a root
+            warnings.append(
+                ScanWarning(
+                    file=nodes[0].source_file,
+                    line=nodes[0].source_line,
+                    message=f"Flow '{flow_name}' has no root nodes (all nodes have dependencies)",
+                )
+            )
+        elif roots:
+            # Build reverse adjacency: parent -> children who depend on it
+            children_of: dict[str, set[str]] = {nid: set() for nid in node_ids}
+            for node in nodes:
+                for dep_id in node.dep_ids:
+                    if dep_id in children_of:
+                        children_of[dep_id].add(node.id)
+
+            # BFS from roots
+            reachable: set[str] = set()
+            queue = list(roots)
+            while queue:
+                current = queue.pop(0)
+                if current in reachable:
+                    continue
+                reachable.add(current)
+                for child in children_of.get(current, set()):
+                    if child not in reachable:
+                        queue.append(child)
+
+            unreachable = node_ids - reachable
+            for nid in unreachable:
+                node = node_map[nid]
+                warnings.append(
+                    ScanWarning(
+                        file=node.source_file,
+                        line=node.source_line,
+                        message=f"Node '{nid}' is unreachable from any root in flow '{flow_name}'",
+                    )
+                )
+
+    return warnings

--- a/core/tests/api/test_scan_endpoint.py
+++ b/core/tests/api/test_scan_endpoint.py
@@ -1,0 +1,407 @@
+"""Tests for POST /v1/nodes/scan — scanner batch upsert endpoint.
+
+Includes both schema validation tests and integration tests that
+hit the actual endpoint, verify DB state, and test auth enforcement.
+"""
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from pydantic import ValidationError
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlmodel import SQLModel, select
+
+from src.api.api import app
+from src.api.middlewares import ensure_api_key
+from src.api.models import ScannedNode, ScanUploadPayload, ScanUploadResponse
+from src.models import Node
+
+# ---------------------------------------------------------------------------
+# Schema validation tests (unit-level)
+# ---------------------------------------------------------------------------
+
+
+def test_scanned_node_minimal():
+    node = ScannedNode(id="checkout_start", flow="checkout", type="act")
+    assert node.id == "checkout_start"
+    assert node.flow == "checkout"
+    assert node.type == "act"
+    assert node.dep_ids == []
+    assert node.description is None
+    assert node.conditions == []
+    assert node.has_filter is False
+    assert node.has_validator is False
+    assert node.source_file is None
+    assert node.source_line is None
+    assert node.source_column is None
+
+
+def test_scanned_node_full():
+    node = ScannedNode(
+        id="payment_processed",
+        flow="checkout",
+        type="assert",
+        dep_ids=["checkout_start"],
+        description="Payment was processed",
+        conditions=[{"timeout_ms": 5000}],
+        has_filter=True,
+        has_validator=True,
+        source_file="src/checkout.ts",
+        source_line=42,
+        source_column=10,
+    )
+    assert node.type == "assert"
+    assert node.dep_ids == ["checkout_start"]
+    assert node.has_filter is True
+    assert node.has_validator is True
+    assert node.source_file == "src/checkout.ts"
+    assert node.source_line == 42
+    assert node.source_column == 10
+    assert len(node.conditions) == 1
+
+
+def test_scanned_node_rejects_invalid_type():
+    with pytest.raises(ValidationError):
+        ScannedNode(id="x", flow="f", type="generic")
+
+
+def test_scanned_node_rejects_missing_required():
+    with pytest.raises(ValidationError):
+        ScannedNode(id="x", type="act")  # missing flow
+
+    with pytest.raises(ValidationError):
+        ScannedNode(flow="f", type="act")  # missing id
+
+
+def test_scan_upload_payload_valid():
+    payload = ScanUploadPayload(
+        scanned_at="2026-03-25T12:00:00Z",
+        files_scanned=5,
+        flows={
+            "checkout": [
+                ScannedNode(id="start", flow="checkout", type="act"),
+                ScannedNode(
+                    id="pay",
+                    flow="checkout",
+                    type="assert",
+                    dep_ids=["start"],
+                ),
+            ],
+            "refund": [
+                ScannedNode(id="refund_start", flow="refund", type="act"),
+            ],
+        },
+    )
+    assert payload.version == "1.0"
+    assert payload.files_scanned == 5
+    assert len(payload.flows) == 2
+    assert len(payload.flows["checkout"]) == 2
+    assert len(payload.flows["refund"]) == 1
+
+
+def test_scan_upload_payload_empty_flows():
+    payload = ScanUploadPayload(
+        scanned_at="2026-03-25T12:00:00Z",
+        files_scanned=0,
+        flows={},
+    )
+    assert payload.flows == {}
+
+
+def test_scan_upload_payload_missing_required():
+    with pytest.raises(ValidationError):
+        ScanUploadPayload(
+            scanned_at="2026-03-25T12:00:00Z",
+            # missing files_scanned
+            flows={},
+        )
+
+
+def test_scan_upload_response():
+    resp = ScanUploadResponse(
+        created=3,
+        updated=1,
+        deleted=2,
+        flows=["checkout", "refund"],
+    )
+    assert resp.created == 3
+    assert resp.updated == 1
+    assert resp.deleted == 2
+    assert resp.flows == ["checkout", "refund"]
+
+
+def test_scan_upload_response_serialization():
+    resp = ScanUploadResponse(
+        created=0,
+        updated=0,
+        deleted=0,
+        flows=[],
+    )
+    data = resp.model_dump()
+    assert data == {
+        "created": 0,
+        "updated": 0,
+        "deleted": 0,
+        "flows": [],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Integration tests — hit the actual POST /v1/nodes/scan endpoint
+# ---------------------------------------------------------------------------
+
+TEST_API_KEY = "test-key-12345"
+
+
+async def _no_op_api_key() -> None:
+    """Bypass API key check for authenticated tests."""
+    return None
+
+
+@pytest_asyncio.fixture
+async def test_session_factory():
+    """Create an in-memory SQLite engine and tables for testing."""
+    engine = create_async_engine(
+        "sqlite+aiosqlite://",
+        connect_args={"check_same_thread": False},
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+
+    factory = async_sessionmaker(
+        expire_on_commit=False,
+        autoflush=True,
+        bind=engine,
+    )
+    yield factory
+
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.drop_all)
+    await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def client(test_session_factory, monkeypatch):
+    """Authenticated async test client with in-memory DB."""
+    import src.db.transactional as txn_module
+
+    monkeypatch.setattr(txn_module, "AsyncSessionLocal", test_session_factory)
+
+    app.dependency_overrides[ensure_api_key] = _no_op_api_key
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+    app.dependency_overrides.clear()
+
+
+@pytest_asyncio.fixture
+async def unauth_client(test_session_factory, monkeypatch):
+    """Unauthenticated async test client (no API key override)."""
+    import src.db.transactional as txn_module
+
+    monkeypatch.setattr(txn_module, "AsyncSessionLocal", test_session_factory)
+
+    app.dependency_overrides.pop(ensure_api_key, None)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+    app.dependency_overrides.clear()
+
+
+def _make_payload(flows: dict[str, list[dict]]) -> dict:
+    return {
+        "version": "1.0",
+        "scanned_at": "2026-03-25T12:00:00Z",
+        "files_scanned": 1,
+        "flows": flows,
+    }
+
+
+# --- Create ---
+
+
+@pytest.mark.asyncio
+async def test_create_nodes(client, test_session_factory):
+    """POST creates new nodes with source='scan'."""
+    payload = _make_payload(
+        {
+            "checkout": [
+                {"id": "cart_created", "flow": "checkout", "type": "act"},
+                {
+                    "id": "payment_ok",
+                    "flow": "checkout",
+                    "type": "assert",
+                    "dep_ids": ["cart_created"],
+                },
+            ]
+        }
+    )
+
+    resp = await client.post("/v1/nodes/scan", json=payload)
+    assert resp.status_code == 200
+
+    data = resp.json()
+    assert data["created"] == 2
+    assert data["updated"] == 0
+    assert data["deleted"] == 0
+    assert "checkout" in data["flows"]
+
+    # Verify DB state
+    async with test_session_factory() as s:
+        nodes = (await s.execute(select(Node))).scalars().all()
+        assert len(nodes) == 2
+        by_id = {n.id: n for n in nodes}
+        assert by_id["cart_created"].source == "scan"
+        assert by_id["cart_created"].flow == "checkout"
+        assert by_id["cart_created"].type == "act"
+        assert by_id["payment_ok"].dep_ids == ["cart_created"]
+
+
+# --- Update ---
+
+
+@pytest.mark.asyncio
+async def test_update_nodes(client, test_session_factory):
+    """Re-POSTing with changed properties updates existing nodes."""
+    # First scan — create
+    payload1 = _make_payload(
+        {
+            "checkout": [
+                {"id": "cart_created", "flow": "checkout", "type": "act"},
+            ]
+        }
+    )
+    resp1 = await client.post("/v1/nodes/scan", json=payload1)
+    assert resp1.json()["created"] == 1
+
+    # Second scan — update with new description
+    payload2 = _make_payload(
+        {
+            "checkout": [
+                {
+                    "id": "cart_created",
+                    "flow": "checkout",
+                    "type": "act",
+                    "description": "Cart was created",
+                },
+            ]
+        }
+    )
+    resp2 = await client.post("/v1/nodes/scan", json=payload2)
+    data2 = resp2.json()
+    assert data2["created"] == 0
+    assert data2["updated"] == 1
+    assert data2["deleted"] == 0
+
+    # Verify DB state
+    async with test_session_factory() as s:
+        node = await s.get(Node, "cart_created")
+        assert node is not None
+        assert node.description == "Cart was created"
+        assert node.source == "scan"
+        assert node.updated_at is not None
+
+
+# --- Stale node cleanup ---
+
+
+@pytest.mark.asyncio
+async def test_stale_node_soft_deleted(client, test_session_factory):
+    """Nodes from a previous scan that are missing in a new scan get soft-deleted."""
+    # First scan — create two nodes
+    payload1 = _make_payload(
+        {
+            "checkout": [
+                {"id": "cart_created", "flow": "checkout", "type": "act"},
+                {
+                    "id": "payment_ok",
+                    "flow": "checkout",
+                    "type": "assert",
+                    "dep_ids": ["cart_created"],
+                },
+            ]
+        }
+    )
+    resp1 = await client.post("/v1/nodes/scan", json=payload1)
+    assert resp1.json()["created"] == 2
+
+    # Second scan — only cart_created remains
+    payload2 = _make_payload(
+        {
+            "checkout": [
+                {"id": "cart_created", "flow": "checkout", "type": "act"},
+            ]
+        }
+    )
+    resp2 = await client.post("/v1/nodes/scan", json=payload2)
+    data2 = resp2.json()
+    assert data2["updated"] == 1  # cart_created re-scanned
+    assert data2["deleted"] == 1  # payment_ok soft-deleted
+
+    # Verify DB state — payment_ok should have deleted_at set
+    async with test_session_factory() as s:
+        payment_node = await s.get(Node, "payment_ok")
+        assert payment_node is not None
+        assert payment_node.deleted_at is not None
+
+        cart_node = await s.get(Node, "cart_created")
+        assert cart_node is not None
+        assert cart_node.deleted_at is None
+
+
+# --- Manual nodes unaffected ---
+
+
+@pytest.mark.asyncio
+async def test_manual_nodes_unaffected(client, test_session_factory):
+    """Scan upsert must not touch nodes with source != 'scan'."""
+    from src.utils.time import now
+
+    # Seed a manual node
+    async with test_session_factory() as s:
+        async with s.begin():
+            manual_node = Node(
+                id="manual_step",
+                flow="checkout",
+                type="act",
+                source="manual",
+                created_at=now(),
+                status="active",
+            )
+            s.add(manual_node)
+
+    # Scan the same flow without manual_step
+    payload = _make_payload(
+        {
+            "checkout": [
+                {"id": "scan_step", "flow": "checkout", "type": "act"},
+            ]
+        }
+    )
+    resp = await client.post("/v1/nodes/scan", json=payload)
+    assert resp.json()["created"] == 1
+    assert resp.json()["deleted"] == 0  # manual node not deleted
+
+    # Verify manual node is untouched
+    async with test_session_factory() as s:
+        manual = await s.get(Node, "manual_step")
+        assert manual is not None
+        assert manual.source == "manual"
+        assert manual.deleted_at is None
+
+
+# --- Auth enforcement ---
+
+
+@pytest.mark.asyncio
+async def test_no_api_key_returns_401(unauth_client):
+    """POST without API key returns 401."""
+    payload = _make_payload(
+        {
+            "checkout": [
+                {"id": "x", "flow": "checkout", "type": "act"},
+            ]
+        }
+    )
+    resp = await unauth_client.post("/v1/nodes/scan", json=payload)
+    assert resp.status_code == 401

--- a/core/tests/scanner/conftest.py
+++ b/core/tests/scanner/conftest.py
@@ -1,0 +1,57 @@
+"""Fixtures for scanner tests."""
+
+from pathlib import Path
+
+import pytest
+
+FIXTURES_DIR = Path(__file__).parent.parent.parent / "e2e-tests" / "js"
+
+
+@pytest.fixture
+def fixtures_dir() -> Path:
+    return FIXTURES_DIR
+
+
+@pytest.fixture
+def basic_flow_path(fixtures_dir: Path) -> str:
+    return str(fixtures_dir / "basic-flow.ts")
+
+
+@pytest.fixture
+def aliased_import_path(fixtures_dir: Path) -> str:
+    return str(fixtures_dir / "aliased-import.ts")
+
+
+@pytest.fixture
+def namespace_import_path(fixtures_dir: Path) -> str:
+    return str(fixtures_dir / "namespace-import.ts")
+
+
+@pytest.fixture
+def no_business_use_path(fixtures_dir: Path) -> str:
+    return str(fixtures_dir / "no-business-use.ts")
+
+
+@pytest.fixture
+def edge_cases_path(fixtures_dir: Path) -> str:
+    return str(fixtures_dir / "edge-cases.ts")
+
+
+@pytest.fixture
+def multiple_flows_path(fixtures_dir: Path) -> str:
+    return str(fixtures_dir / "multiple-flows.ts")
+
+
+@pytest.fixture
+def jsx_component_path(fixtures_dir: Path) -> str:
+    return str(fixtures_dir / "jsx-component.tsx")
+
+
+@pytest.fixture
+def helpers_usage_path(fixtures_dir: Path) -> str:
+    return str(fixtures_dir / "helpers-usage.ts")
+
+
+@pytest.fixture
+def require_pattern_path(fixtures_dir: Path) -> str:
+    return str(fixtures_dir / "require-pattern.js")

--- a/core/tests/scanner/test_api_client.py
+++ b/core/tests/scanner/test_api_client.py
@@ -1,0 +1,95 @@
+"""Test API client with mocked httpx responses."""
+
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from src.scanner.api_client import ScanPushError, _build_payload, push_scan_result
+from src.scanner.models import ExtractedNode, ScanResult
+
+
+def _sample_result() -> ScanResult:
+    return ScanResult(
+        files_scanned=1,
+        flows={
+            "checkout": [
+                ExtractedNode(
+                    id="cart_created",
+                    flow="checkout",
+                    type="act",
+                    source_file="src/cart.ts",
+                    source_line=10,
+                    source_column=1,
+                ),
+            ]
+        },
+    )
+
+
+class TestBuildPayload:
+    def test_basic_payload(self):
+        result = _sample_result()
+        payload = _build_payload(result)
+        assert payload["version"] == "1.0"
+        assert payload["files_scanned"] == 1
+        assert "checkout" in payload["flows"]
+        assert len(payload["flows"]["checkout"]) == 1
+        node = payload["flows"]["checkout"][0]
+        assert node["id"] == "cart_created"
+        assert node["flow"] == "checkout"
+        assert node["type"] == "act"
+
+    def test_excludes_warnings(self):
+        result = _sample_result()
+        payload = _build_payload(result)
+        # Warnings should not be in payload
+        assert "warnings" not in payload
+        for nodes in payload["flows"].values():
+            for node in nodes:
+                assert "warnings" not in node
+
+
+class TestPushScanResult:
+    def test_success(self):
+        result = _sample_result()
+        mock_response = httpx.Response(
+            200,
+            json={"created": 1, "updated": 0, "deleted": 0, "flows": ["checkout"]},
+        )
+        with patch("src.scanner.api_client.httpx.post", return_value=mock_response):
+            resp = push_scan_result(result, "http://localhost:13370", "test-key")
+        assert resp["created"] == 1
+        assert resp["flows"] == ["checkout"]
+
+    def test_auth_failure(self):
+        result = _sample_result()
+        mock_response = httpx.Response(401, text="Unauthorized")
+        with patch("src.scanner.api_client.httpx.post", return_value=mock_response):
+            with pytest.raises(ScanPushError, match="Authentication failed"):
+                push_scan_result(result, "http://localhost:13370", "bad-key")
+
+    def test_server_error(self):
+        result = _sample_result()
+        mock_response = httpx.Response(500, text="Internal Server Error")
+        with patch("src.scanner.api_client.httpx.post", return_value=mock_response):
+            with pytest.raises(ScanPushError, match="Server error"):
+                push_scan_result(result, "http://localhost:13370", "test-key")
+
+    def test_connection_error(self):
+        result = _sample_result()
+        with patch(
+            "src.scanner.api_client.httpx.post",
+            side_effect=httpx.ConnectError("Connection refused"),
+        ):
+            with pytest.raises(ScanPushError, match="Connection refused"):
+                push_scan_result(result, "http://localhost:99999", "test-key")
+
+    def test_timeout_error(self):
+        result = _sample_result()
+        with patch(
+            "src.scanner.api_client.httpx.post",
+            side_effect=httpx.ReadTimeout("timeout"),
+        ):
+            with pytest.raises(ScanPushError, match="timed out"):
+                push_scan_result(result, "http://localhost:13370", "test-key")

--- a/core/tests/scanner/test_extractor.py
+++ b/core/tests/scanner/test_extractor.py
@@ -1,0 +1,93 @@
+"""Test node extraction against each e2e fixture."""
+
+from src.scanner.extractor import scan_file
+
+
+def test_basic_flow(basic_flow_path: str):
+    nodes, warnings, skipped = scan_file(basic_flow_path)
+    assert not skipped
+    assert len(nodes) == 3
+    ids = {n.id for n in nodes}
+    assert "cart_created" in ids
+    assert "payment_processed" in ids
+    assert "order_total_matches" in ids
+    # All should be in checkout flow
+    assert all(n.flow == "checkout" for n in nodes)
+
+
+def test_basic_flow_types(basic_flow_path: str):
+    nodes, _, _ = scan_file(basic_flow_path)
+    node_map = {n.id: n for n in nodes}
+    # ensure() without validator -> act
+    assert node_map["cart_created"].type == "act"
+    # ensure() with validator -> assert
+    assert node_map["order_total_matches"].type == "assert"
+
+
+def test_basic_flow_dep_ids(basic_flow_path: str):
+    nodes, _, _ = scan_file(basic_flow_path)
+    node_map = {n.id: n for n in nodes}
+    assert node_map["cart_created"].dep_ids == []
+    assert "cart_created" in node_map["payment_processed"].dep_ids
+
+
+def test_aliased_import(aliased_import_path: str):
+    nodes, _, skipped = scan_file(aliased_import_path)
+    assert not skipped
+    assert len(nodes) >= 1
+    # Aliased imports should still be detected
+    ids = {n.id for n in nodes}
+    assert len(ids) > 0
+
+
+def test_namespace_import(namespace_import_path: str):
+    nodes, _, skipped = scan_file(namespace_import_path)
+    assert not skipped
+    assert len(nodes) >= 1
+
+
+def test_no_business_use(no_business_use_path: str):
+    nodes, _, skipped = scan_file(no_business_use_path)
+    assert skipped
+    assert len(nodes) == 0
+
+
+def test_require_pattern(require_pattern_path: str):
+    nodes, _, skipped = scan_file(require_pattern_path)
+    assert skipped
+    assert len(nodes) == 0
+
+
+def test_edge_cases(edge_cases_path: str):
+    nodes, warnings, skipped = scan_file(edge_cases_path)
+    assert not skipped
+    # Edge cases file should produce some nodes and some warnings
+    # (dynamic values, spreads, etc. generate warnings)
+
+
+def test_multiple_flows(multiple_flows_path: str):
+    nodes, _, skipped = scan_file(multiple_flows_path)
+    assert not skipped
+    flows = {n.flow for n in nodes}
+    assert len(flows) >= 2
+
+
+def test_jsx_component(jsx_component_path: str):
+    nodes, _, skipped = scan_file(jsx_component_path)
+    assert not skipped
+    assert len(nodes) >= 1
+
+
+def test_helpers_usage(helpers_usage_path: str):
+    nodes, _, skipped = scan_file(helpers_usage_path)
+    # helpers-usage might or might not have direct imports depending on fixture
+    # Just verify it doesn't crash
+    assert isinstance(nodes, list)
+
+
+def test_source_location(basic_flow_path: str):
+    nodes, _, _ = scan_file(basic_flow_path)
+    for node in nodes:
+        assert node.source_file == basic_flow_path
+        assert node.source_line > 0
+        assert node.source_column > 0

--- a/core/tests/scanner/test_formatters.py
+++ b/core/tests/scanner/test_formatters.py
@@ -1,0 +1,146 @@
+"""Tests for scanner output formatters."""
+
+import json
+
+from src.scanner.formatters import format_json, format_table
+from src.scanner.models import ExtractedNode, ScanResult, ScanWarning
+
+
+def _make_result() -> ScanResult:
+    """Create a sample ScanResult for testing."""
+    return ScanResult(
+        version="1.0",
+        scanned_at="2026-01-01T00:00:00+00:00",
+        files_scanned=2,
+        files_skipped=0,
+        flows={
+            "checkout": [
+                ExtractedNode(
+                    id="cart_created",
+                    flow="checkout",
+                    type="act",
+                    dep_ids=[],
+                    source_file="src/cart/service.ts",
+                    source_line=42,
+                ),
+                ExtractedNode(
+                    id="payment_processed",
+                    flow="checkout",
+                    type="assert",
+                    dep_ids=["cart_created"],
+                    has_validator=True,
+                    source_file="src/payment/handler.ts",
+                    source_line=18,
+                ),
+            ],
+        },
+        warnings=[
+            ScanWarning(
+                file="src/utils/helper.ts",
+                line=22,
+                message="ensure() call with non-literal 'id' argument, skipped",
+            ),
+        ],
+    )
+
+
+class TestFormatJson:
+    def test_valid_json(self) -> None:
+        result = _make_result()
+        output = format_json(result)
+        parsed = json.loads(output)
+        assert isinstance(parsed, dict)
+
+    def test_contains_expected_keys(self) -> None:
+        result = _make_result()
+        output = format_json(result)
+        parsed = json.loads(output)
+        assert "version" in parsed
+        assert "scanned_at" in parsed
+        assert "files_scanned" in parsed
+        assert "flows" in parsed
+        assert "warnings" in parsed
+
+    def test_flows_structure(self) -> None:
+        result = _make_result()
+        output = format_json(result)
+        parsed = json.loads(output)
+        assert "checkout" in parsed["flows"]
+        assert len(parsed["flows"]["checkout"]) == 2
+
+    def test_empty_result(self) -> None:
+        result = ScanResult(scanned_at="2026-01-01T00:00:00+00:00")
+        output = format_json(result)
+        parsed = json.loads(output)
+        assert parsed["flows"] == {}
+        assert parsed["warnings"] == []
+        assert parsed["files_scanned"] == 0
+
+
+class TestFormatTable:
+    def test_contains_columns(self) -> None:
+        result = _make_result()
+        output = format_table(result)
+        assert "ID" in output
+        assert "Type" in output
+        assert "Dep IDs" in output
+        assert "Source" in output
+
+    def test_contains_flow_name(self) -> None:
+        result = _make_result()
+        output = format_table(result)
+        assert "Flow: checkout (2 nodes)" in output
+
+    def test_contains_node_data(self) -> None:
+        result = _make_result()
+        output = format_table(result)
+        assert "cart_created" in output
+        assert "payment_processed" in output
+        assert "src/cart/service.ts:42" in output
+
+    def test_contains_warnings(self) -> None:
+        result = _make_result()
+        output = format_table(result)
+        assert "Warnings (1):" in output
+        assert "src/utils/helper.ts:22" in output
+
+    def test_empty_result(self) -> None:
+        result = ScanResult(scanned_at="2026-01-01T00:00:00+00:00")
+        output = format_table(result)
+        assert "No flows found." in output
+
+    def test_node_without_deps_shows_dash(self) -> None:
+        result = _make_result()
+        output = format_table(result)
+        # cart_created has no deps, should show em-dash
+        assert "\u2014" in output
+
+
+class TestFlowFilter:
+    def test_filter_matching_flow(self) -> None:
+        result = _make_result()
+        # Simulate flow filter like the CLI does
+        flow_filter = "checkout"
+        if flow_filter in result.flows:
+            result.flows = {flow_filter: result.flows[flow_filter]}
+        output = format_json(result)
+        parsed = json.loads(output)
+        assert "checkout" in parsed["flows"]
+        assert len(parsed["flows"]) == 1
+
+    def test_filter_non_matching_flow(self) -> None:
+        result = _make_result()
+        flow_filter = "nonexistent"
+        if flow_filter in result.flows:
+            result.flows = {flow_filter: result.flows[flow_filter]}
+        else:
+            result.flows = {}
+        output = format_json(result)
+        parsed = json.loads(output)
+        assert parsed["flows"] == {}
+
+    def test_filter_applied_to_table(self) -> None:
+        result = _make_result()
+        result.flows = {}
+        output = format_table(result)
+        assert "No flows found." in output

--- a/core/tests/scanner/test_imports.py
+++ b/core/tests/scanner/test_imports.py
@@ -1,0 +1,38 @@
+"""Test import detection for various import patterns."""
+
+from src.scanner.imports import extract_imports
+from src.scanner.parser import parse_file
+
+
+def test_named_imports(basic_flow_path: str):
+    tree = parse_file(basic_flow_path)
+    imports = extract_imports(tree.root_node)
+    assert imports.has_imports
+    assert "ensure" in imports.named or imports.aliases or imports.namespace
+
+
+def test_aliased_imports(aliased_import_path: str):
+    tree = parse_file(aliased_import_path)
+    imports = extract_imports(tree.root_node)
+    assert imports.has_imports
+    assert len(imports.aliases) > 0
+
+
+def test_namespace_imports(namespace_import_path: str):
+    tree = parse_file(namespace_import_path)
+    imports = extract_imports(tree.root_node)
+    assert imports.has_imports
+    assert imports.namespace is not None
+
+
+def test_no_business_use_imports(no_business_use_path: str):
+    tree = parse_file(no_business_use_path)
+    imports = extract_imports(tree.root_node)
+    assert not imports.has_imports
+
+
+def test_require_pattern_no_imports(require_pattern_path: str):
+    """CJS require() is not detected as an import (by design)."""
+    tree = parse_file(require_pattern_path)
+    imports = extract_imports(tree.root_node)
+    assert not imports.has_imports

--- a/core/tests/scanner/test_validator.py
+++ b/core/tests/scanner/test_validator.py
@@ -1,0 +1,105 @@
+"""Test graph validation: broken refs, duplicates, unreachable nodes."""
+
+from src.scanner.models import ExtractedNode
+from src.scanner.validator import validate_graph
+
+
+def _node(
+    id: str,
+    flow: str = "test",
+    dep_ids: list[str] | None = None,
+    source_file: str = "test.ts",
+    source_line: int = 1,
+) -> ExtractedNode:
+    return ExtractedNode(
+        id=id,
+        flow=flow,
+        type="act",
+        dep_ids=dep_ids or [],
+        source_file=source_file,
+        source_line=source_line,
+    )
+
+
+def test_valid_graph():
+    flows = {
+        "checkout": [
+            _node("root", dep_ids=[]),
+            _node("child", dep_ids=["root"]),
+        ]
+    }
+    warnings = validate_graph(flows)
+    assert len(warnings) == 0
+
+
+def test_broken_dep_ids_reference():
+    flows = {
+        "checkout": [
+            _node("root"),
+            _node("child", dep_ids=["nonexistent"]),
+        ]
+    }
+    warnings = validate_graph(flows)
+    # Broken dep ref + unreachable (since dep doesn't exist, can't reach from root)
+    assert len(warnings) == 2
+    messages = [w.message for w in warnings]
+    assert any("nonexistent" in m for m in messages)
+    assert any("unreachable" in m for m in messages)
+
+
+def test_duplicate_node_ids():
+    flows = {
+        "checkout": [
+            _node("root"),
+            _node("root", source_line=10),
+        ]
+    }
+    warnings = validate_graph(flows)
+    assert any("Duplicate" in w.message for w in warnings)
+
+
+def test_unreachable_node():
+    flows = {
+        "checkout": [
+            _node("root"),
+            _node("child", dep_ids=["root"]),
+            _node("orphan", dep_ids=["missing"]),
+        ]
+    }
+    warnings = validate_graph(flows)
+    # Should warn about missing dep_id AND orphan being unreachable
+    messages = [w.message for w in warnings]
+    assert any("missing" in m for m in messages)
+
+
+def test_no_root_nodes():
+    flows = {
+        "checkout": [
+            _node("a", dep_ids=["b"]),
+            _node("b", dep_ids=["a"]),
+        ]
+    }
+    warnings = validate_graph(flows)
+    assert any("no root nodes" in w.message for w in warnings)
+
+
+def test_empty_flows():
+    warnings = validate_graph({})
+    assert len(warnings) == 0
+
+
+def test_multiple_flows_validated_independently():
+    flows = {
+        "flow_a": [
+            _node("root", flow="flow_a"),
+            _node("child", flow="flow_a", dep_ids=["root"]),
+        ],
+        "flow_b": [
+            _node("root", flow="flow_b"),
+            _node("child", flow="flow_b", dep_ids=["nonexistent"]),
+        ],
+    }
+    warnings = validate_graph(flows)
+    # Only flow_b should have warnings (broken ref + unreachable)
+    assert len(warnings) == 2
+    assert all("flow_b" in w.message for w in warnings)

--- a/core/uv.lock
+++ b/core/uv.lock
@@ -122,11 +122,22 @@ dependencies = [
     { name = "uuid" },
 ]
 
+[package.optional-dependencies]
+scan = [
+    { name = "tree-sitter" },
+    { name = "tree-sitter-javascript" },
+    { name = "tree-sitter-typescript" },
+]
+
 [package.dev-dependencies]
 dev = [
     { name = "mypy" },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "ruff" },
+    { name = "tree-sitter" },
+    { name = "tree-sitter-javascript" },
+    { name = "tree-sitter-typescript" },
     { name = "types-pyyaml" },
 ]
 
@@ -145,14 +156,22 @@ requires-dist = [
     { name = "questionary", specifier = ">=2.1.0" },
     { name = "quickjs", specifier = ">=1.19.2" },
     { name = "sqlmodel", specifier = ">=0.0.27" },
+    { name = "tree-sitter", marker = "extra == 'scan'", specifier = ">=0.25.0" },
+    { name = "tree-sitter-javascript", marker = "extra == 'scan'", specifier = ">=0.25.0" },
+    { name = "tree-sitter-typescript", marker = "extra == 'scan'", specifier = ">=0.23.0" },
     { name = "uuid", specifier = ">=1.30" },
 ]
+provides-extras = ["scan"]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "mypy", specifier = ">=1.13.0" },
     { name = "pytest", specifier = ">=8.0.0" },
+    { name = "pytest-asyncio", specifier = ">=0.24.0" },
     { name = "ruff", specifier = ">=0.8.0" },
+    { name = "tree-sitter", specifier = ">=0.25.0" },
+    { name = "tree-sitter-javascript", specifier = ">=0.25.0" },
+    { name = "tree-sitter-typescript", specifier = ">=0.23.0" },
     { name = "types-pyyaml", specifier = ">=6.0.12.20250915" },
 ]
 
@@ -706,6 +725,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-asyncio"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
+]
+
+[[package]]
 name = "python-dotenv"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -999,6 +1031,66 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a7/a5/d6f429d43394057b67a6b5bbe6eae2f77a6bf7459d961fdb224bf206eee6/starlette-0.48.0.tar.gz", hash = "sha256:7e8cee469a8ab2352911528110ce9088fdc6a37d9876926e73da7ce4aa4c7a46", size = 2652949, upload-time = "2025-09-13T08:41:05.699Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/be/72/2db2f49247d0a18b4f1bb9a5a39a0162869acf235f3a96418363947b3d46/starlette-0.48.0-py3-none-any.whl", hash = "sha256:0764ca97b097582558ecb498132ed0c7d942f233f365b86ba37770e026510659", size = 73736, upload-time = "2025-09-13T08:41:03.869Z" },
+]
+
+[[package]]
+name = "tree-sitter"
+version = "0.25.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/7c/0350cfc47faadc0d3cf7d8237a4e34032b3014ddf4a12ded9933e1648b55/tree-sitter-0.25.2.tar.gz", hash = "sha256:fe43c158555da46723b28b52e058ad444195afd1db3ca7720c59a254544e9c20", size = 177961, upload-time = "2025-09-25T17:37:59.751Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3c/9e/20c2a00a862f1c2897a436b17edb774e831b22218083b459d0d081c9db33/tree_sitter-0.25.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:ddabfff809ffc983fc9963455ba1cecc90295803e06e140a4c83e94c1fa3d960", size = 146941, upload-time = "2025-09-25T17:37:34.813Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/04/8512e2062e652a1016e840ce36ba1cc33258b0dcc4e500d8089b4054afec/tree_sitter-0.25.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c0c0ab5f94938a23fe81928a21cc0fac44143133ccc4eb7eeb1b92f84748331c", size = 137699, upload-time = "2025-09-25T17:37:36.349Z" },
+    { url = "https://files.pythonhosted.org/packages/47/8a/d48c0414db19307b0fb3bb10d76a3a0cbe275bb293f145ee7fba2abd668e/tree_sitter-0.25.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dd12d80d91d4114ca097626eb82714618dcdfacd6a5e0955216c6485c350ef99", size = 607125, upload-time = "2025-09-25T17:37:37.725Z" },
+    { url = "https://files.pythonhosted.org/packages/39/d1/b95f545e9fc5001b8a78636ef942a4e4e536580caa6a99e73dd0a02e87aa/tree_sitter-0.25.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b43a9e4c89d4d0839de27cd4d6902d33396de700e9ff4c5ab7631f277a85ead9", size = 635418, upload-time = "2025-09-25T17:37:38.922Z" },
+    { url = "https://files.pythonhosted.org/packages/de/4d/b734bde3fb6f3513a010fa91f1f2875442cdc0382d6a949005cd84563d8f/tree_sitter-0.25.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fbb1706407c0e451c4f8cc016fec27d72d4b211fdd3173320b1ada7a6c74c3ac", size = 631250, upload-time = "2025-09-25T17:37:40.039Z" },
+    { url = "https://files.pythonhosted.org/packages/46/f2/5f654994f36d10c64d50a192239599fcae46677491c8dd53e7579c35a3e3/tree_sitter-0.25.2-cp312-cp312-win_amd64.whl", hash = "sha256:6d0302550bbe4620a5dc7649517c4409d74ef18558276ce758419cf09e578897", size = 127156, upload-time = "2025-09-25T17:37:41.132Z" },
+    { url = "https://files.pythonhosted.org/packages/67/23/148c468d410efcf0a9535272d81c258d840c27b34781d625f1f627e2e27d/tree_sitter-0.25.2-cp312-cp312-win_arm64.whl", hash = "sha256:0c8b6682cac77e37cfe5cf7ec388844957f48b7bd8d6321d0ca2d852994e10d5", size = 113984, upload-time = "2025-09-25T17:37:42.074Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/67/67492014ce32729b63d7ef318a19f9cfedd855d677de5773476caf771e96/tree_sitter-0.25.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0628671f0de69bb279558ef6b640bcfc97864fe0026d840f872728a86cd6b6cd", size = 146926, upload-time = "2025-09-25T17:37:43.041Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/9c/a278b15e6b263e86c5e301c82a60923fa7c59d44f78d7a110a89a413e640/tree_sitter-0.25.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f5ddcd3e291a749b62521f71fc953f66f5fd9743973fd6dd962b092773569601", size = 137712, upload-time = "2025-09-25T17:37:44.039Z" },
+    { url = "https://files.pythonhosted.org/packages/54/9a/423bba15d2bf6473ba67846ba5244b988cd97a4b1ea2b146822162256794/tree_sitter-0.25.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bd88fbb0f6c3a0f28f0a68d72df88e9755cf5215bae146f5a1bdc8362b772053", size = 607873, upload-time = "2025-09-25T17:37:45.477Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/4c/b430d2cb43f8badfb3a3fa9d6cd7c8247698187b5674008c9d67b2a90c8e/tree_sitter-0.25.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b878e296e63661c8e124177cc3084b041ba3f5936b43076d57c487822426f614", size = 636313, upload-time = "2025-09-25T17:37:46.68Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/27/5f97098dbba807331d666a0997662e82d066e84b17d92efab575d283822f/tree_sitter-0.25.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:d77605e0d353ba3fe5627e5490f0fbfe44141bafa4478d88ef7954a61a848dae", size = 631370, upload-time = "2025-09-25T17:37:47.993Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/3c/87caaed663fabc35e18dc704cd0e9800a0ee2f22bd18b9cbe7c10799895d/tree_sitter-0.25.2-cp313-cp313-win_amd64.whl", hash = "sha256:463c032bd02052d934daa5f45d183e0521ceb783c2548501cf034b0beba92c9b", size = 127157, upload-time = "2025-09-25T17:37:48.967Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/23/f8467b408b7988aff4ea40946a4bd1a2c1a73d17156a9d039bbaff1e2ceb/tree_sitter-0.25.2-cp313-cp313-win_arm64.whl", hash = "sha256:b3f63a1796886249bd22c559a5944d64d05d43f2be72961624278eff0dcc5cb8", size = 113975, upload-time = "2025-09-25T17:37:49.922Z" },
+    { url = "https://files.pythonhosted.org/packages/07/e3/d9526ba71dfbbe4eba5e51d89432b4b333a49a1e70712aa5590cd22fc74f/tree_sitter-0.25.2-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:65d3c931013ea798b502782acab986bbf47ba2c452610ab0776cf4a8ef150fc0", size = 146776, upload-time = "2025-09-25T17:37:50.898Z" },
+    { url = "https://files.pythonhosted.org/packages/42/97/4bd4ad97f85a23011dd8a535534bb1035c4e0bac1234d58f438e15cff51f/tree_sitter-0.25.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:bda059af9d621918efb813b22fb06b3fe00c3e94079c6143fcb2c565eb44cb87", size = 137732, upload-time = "2025-09-25T17:37:51.877Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/19/1e968aa0b1b567988ed522f836498a6a9529a74aab15f09dd9ac1e41f505/tree_sitter-0.25.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:eac4e8e4c7060c75f395feec46421eb61212cb73998dbe004b7384724f3682ab", size = 609456, upload-time = "2025-09-25T17:37:52.925Z" },
+    { url = "https://files.pythonhosted.org/packages/48/b6/cf08f4f20f4c9094006ef8828555484e842fc468827ad6e56011ab668dbd/tree_sitter-0.25.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:260586381b23be33b6191a07cea3d44ecbd6c01aa4c6b027a0439145fcbc3358", size = 636772, upload-time = "2025-09-25T17:37:54.647Z" },
+    { url = "https://files.pythonhosted.org/packages/57/e2/d42d55bf56360987c32bc7b16adb06744e425670b823fb8a5786a1cea991/tree_sitter-0.25.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7d2ee1acbacebe50ba0f85fff1bc05e65d877958f00880f49f9b2af38dce1af0", size = 631522, upload-time = "2025-09-25T17:37:55.833Z" },
+    { url = "https://files.pythonhosted.org/packages/03/87/af9604ebe275a9345d88c3ace0cf2a1341aa3f8ef49dd9fc11662132df8a/tree_sitter-0.25.2-cp314-cp314-win_amd64.whl", hash = "sha256:4973b718fcadfb04e59e746abfbb0288694159c6aeecd2add59320c03368c721", size = 130864, upload-time = "2025-09-25T17:37:57.453Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/6e/e64621037357acb83d912276ffd30a859ef117f9c680f2e3cb955f47c680/tree_sitter-0.25.2-cp314-cp314-win_arm64.whl", hash = "sha256:b8d4429954a3beb3e844e2872610d2a4800ba4eb42bb1990c6a4b1949b18459f", size = 117470, upload-time = "2025-09-25T17:37:58.431Z" },
+]
+
+[[package]]
+name = "tree-sitter-javascript"
+version = "0.25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/59/e0/e63103c72a9d3dfd89a31e02e660263ad84b7438e5f44ee82e443e65bbde/tree_sitter_javascript-0.25.0.tar.gz", hash = "sha256:329b5414874f0588a98f1c291f1b28138286617aa907746ffe55adfdcf963f38", size = 132338, upload-time = "2025-09-01T07:13:44.792Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/df/5106ac250cd03661ebc3cc75da6b3d9f6800a3606393a0122eca58038104/tree_sitter_javascript-0.25.0-cp310-abi3-macosx_10_9_x86_64.whl", hash = "sha256:b70f887fb269d6e58c349d683f59fa647140c410cfe2bee44a883b20ec92e3dc", size = 64052, upload-time = "2025-09-01T07:13:36.865Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/8f/6b4b2bc90d8ab3955856ce852cc9d1e82c81d7ab9646385f0e75ffd5b5d3/tree_sitter_javascript-0.25.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:8264a996b8845cfce06965152a013b5d9cbb7d199bc3503e12b5682e62bb1de1", size = 66440, upload-time = "2025-09-01T07:13:37.962Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/c4/7da74ecdcd8a398f88bd003a87c65403b5fe0e958cdd43fbd5fd4a398fcf/tree_sitter_javascript-0.25.0-cp310-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9dc04ba91fc8583344e57c1f1ed5b2c97ecaaf47480011b92fbeab8dda96db75", size = 99728, upload-time = "2025-09-01T07:13:38.755Z" },
+    { url = "https://files.pythonhosted.org/packages/96/c8/97da3af4796495e46421e9344738addb3602fa6426ea695be3fcbadbee37/tree_sitter_javascript-0.25.0-cp310-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:199d09985190852e0912da2b8d26c932159be314bc04952cf917ed0e4c633e6b", size = 106072, upload-time = "2025-09-01T07:13:39.798Z" },
+    { url = "https://files.pythonhosted.org/packages/13/be/c964e8130be08cc9bd6627d845f0e4460945b158429d39510953bbcb8fcc/tree_sitter_javascript-0.25.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:dfcf789064c58dc13c0a4edb550acacfc6f0f280577f1e7a00de3e89fc7f8ddc", size = 104388, upload-time = "2025-09-01T07:13:40.866Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/89/9b773dee0f8961d1bb8d7baf0a204ab587618df19897c1ef260916f318ec/tree_sitter_javascript-0.25.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:1b852d3aee8a36186dbcc32c798b11b4869f9b5041743b63b65c2ef793db7a54", size = 98377, upload-time = "2025-09-01T07:13:41.838Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/dc/d90cb1790f8cec9b4878d278ad9faf7c8f893189ce0f855304fd704fc274/tree_sitter_javascript-0.25.0-cp310-abi3-win_amd64.whl", hash = "sha256:e5ed840f5bd4a3f0272e441d19429b26eedc257abe5574c8546da6b556865e3c", size = 62975, upload-time = "2025-09-01T07:13:42.828Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/1f/f9eba1038b7d4394410f3c0a6ec2122b590cd7acb03f196e52fa57ebbe72/tree_sitter_javascript-0.25.0-cp310-abi3-win_arm64.whl", hash = "sha256:622a69d677aa7f6ee2931d8c77c981a33f0ebb6d275aa9d43d3397c879a9bb0b", size = 61668, upload-time = "2025-09-01T07:13:43.803Z" },
+]
+
+[[package]]
+name = "tree-sitter-typescript"
+version = "0.23.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1e/fc/bb52958f7e399250aee093751e9373a6311cadbe76b6e0d109b853757f35/tree_sitter_typescript-0.23.2.tar.gz", hash = "sha256:7b167b5827c882261cb7a50dfa0fb567975f9b315e87ed87ad0a0a3aedb3834d", size = 773053, upload-time = "2024-11-11T02:36:11.396Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/28/95/4c00680866280e008e81dd621fd4d3f54aa3dad1b76b857a19da1b2cc426/tree_sitter_typescript-0.23.2-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:3cd752d70d8e5371fdac6a9a4df9d8924b63b6998d268586f7d374c9fba2a478", size = 286677, upload-time = "2024-11-11T02:35:58.839Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/2f/1f36fda564518d84593f2740d5905ac127d590baf5c5753cef2a88a89c15/tree_sitter_typescript-0.23.2-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:c7cc1b0ff5d91bac863b0e38b1578d5505e718156c9db577c8baea2557f66de8", size = 302008, upload-time = "2024-11-11T02:36:00.733Z" },
+    { url = "https://files.pythonhosted.org/packages/96/2d/975c2dad292aa9994f982eb0b69cc6fda0223e4b6c4ea714550477d8ec3a/tree_sitter_typescript-0.23.2-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4b1eed5b0b3a8134e86126b00b743d667ec27c63fc9de1b7bb23168803879e31", size = 351987, upload-time = "2024-11-11T02:36:02.669Z" },
+    { url = "https://files.pythonhosted.org/packages/49/d1/a71c36da6e2b8a4ed5e2970819b86ef13ba77ac40d9e333cb17df6a2c5db/tree_sitter_typescript-0.23.2-cp39-abi3-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e96d36b85bcacdeb8ff5c2618d75593ef12ebaf1b4eace3477e2bdb2abb1752c", size = 344960, upload-time = "2024-11-11T02:36:04.443Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/cb/f57b149d7beed1a85b8266d0c60ebe4c46e79c9ba56bc17b898e17daf88e/tree_sitter_typescript-0.23.2-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:8d4f0f9bcb61ad7b7509d49a1565ff2cc363863644a234e1e0fe10960e55aea0", size = 340245, upload-time = "2024-11-11T02:36:06.473Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/ab/dd84f0e2337296a5f09749f7b5483215d75c8fa9e33738522e5ed81f7254/tree_sitter_typescript-0.23.2-cp39-abi3-win_amd64.whl", hash = "sha256:3f730b66396bc3e11811e4465c41ee45d9e9edd6de355a58bbbc49fa770da8f9", size = 278015, upload-time = "2024-11-11T02:36:07.631Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/e4/81f9a935789233cf412a0ed5fe04c883841d2c8fb0b7e075958a35c65032/tree_sitter_typescript-0.23.2-cp39-abi3-win_arm64.whl", hash = "sha256:05db58f70b95ef0ea126db5560f3775692f609589ed6f8dd0af84b7f19f1cbb7", size = 274052, upload-time = "2024-11-11T02:36:09.514Z" },
 ]
 
 [[package]]

--- a/thoughts/taras/plans/2026-03-25-scanner-cli.md
+++ b/thoughts/taras/plans/2026-03-25-scanner-cli.md
@@ -1,0 +1,516 @@
+---
+date: 2026-03-25
+author: Claude
+status: completed
+autonomy: critical
+based_on: thoughts/taras/research/2026-03-25-static-analysis-sdk-extraction.md
+---
+
+# Scanner CLI Implementation Plan
+
+## Overview
+
+Implement `business-use scan` — a CLI command that statically analyzes JS/TS codebases to extract all `ensure()`, `act()`, `assert()` SDK call sites and push the resulting flow graph to the backend API. This enables automatic node registration without runtime execution, making it ideal for CI/CD integration.
+
+## Current State Analysis
+
+### What exists:
+- **POC scanner** (`core/e2e-tests/poc_scanner.py`): ~365 lines, uses py-tree-sitter, tested against 9 JS/TS fixtures. Handles imports (named, aliased, namespace), string extraction, type inference, and graceful degradation on non-extractable values.
+- **E2E fixtures** (`core/e2e-tests/js/` and `core/e2e-tests/py/`): 9 JS/TS files + 4 Python files covering happy path, edge cases, aliased imports, namespace imports, TSX, CJS require, and no-import scenarios.
+- **CLI framework**: Click-based (`core/src/cli.py`), with existing groups (`workspace`, `db`, `server`, `flow`, `nodes`). The `nodes sync` command already does YAML → DB upsert with `source="code"`.
+- **Node model** (`core/src/models.py:154-228`): Supports `act`/`assert` types, `source` field (`"code"`/`"manual"`), `dep_ids`, `conditions`, `description`.
+- **API**: `POST /v1/nodes` exists but only accepts `generic`/`trigger`/`hook` types (`core/src/api/models.py:55-61`). No batch upsert endpoint.
+
+### What's missing:
+- Production scanner module in `core/src/`
+- `business-use scan` CLI command
+- Batch upsert API endpoint accepting `act`/`assert` types from scanner
+- tree-sitter dependencies in `pyproject.toml`
+- Unit/integration tests for scanner
+
+### Key Discoveries:
+- `NodeCreateSchema` restricts `type` to `generic|trigger|hook` (`core/src/api/models.py:61`) — scanner-pushed nodes need a separate schema allowing `act|assert`
+- `NodeYAMLCreateSchema` already allows any `NodeType` (`core/src/api/models.py:64-67`) — could be reused or adapted
+- `nodes sync` uses `source="code"` for YAML-synced nodes (`core/src/cli.py:1383`) — scanner should use a distinct source like `"scan"` to differentiate
+- **`NodeSource` only allows `"code"` or `"manual"`** (`core/src/models.py:68-71`) — must be extended to include `"scan"` before using it as a source value
+- **POC `TARGET_MODULES` only checks `"business-use"` and `"business_use"`** (`poc_scanner.py:19`) — must also match `@desplega.ai/business-use` (the actual scoped npm package name from `sdk-js/package.json:2`)
+- POC scanner output format groups nodes by flow with source location — maps well to the Node model
+- The `httpx` library is already a dependency (`core/pyproject.toml:38`) — can use it for API calls from scanner
+
+## Desired End State
+
+A working `business-use scan` command that:
+
+```bash
+# Dry-run: scan JS/TS files, print extracted nodes (no backend needed)
+business-use scan ./src --dry-run
+business-use scan ./src --dry-run --format table
+
+# Push to backend API
+business-use scan ./src --url http://localhost:13370 --api-key <key>
+
+# Validate graph integrity without pushing
+business-use scan ./src --validate
+
+# Filter by flow
+business-use scan ./src --flow checkout --dry-run
+```
+
+Verified by:
+1. Scanner correctly extracts nodes from all 9 existing JS/TS fixture files
+2. `--dry-run` outputs valid JSON matching the research spec
+3. `--validate` catches broken `depIds` references and duplicate IDs
+4. API push creates/updates nodes in backend with `source="scan"`
+5. CI/CD integration works: `uvx business-use-core scan ./src --url $URL --api-key $KEY`
+
+## Quick Verification Reference
+
+Common commands:
+- `cd core && uv run pytest tests/scanner/ -v` — scanner unit tests
+- `cd core && uv run ruff format src/scanner/ tests/scanner/` — format
+- `cd core && uv run ruff check src/scanner/ tests/scanner/ --fix` — lint
+- `cd core && uv run mypy src/scanner/` — type check
+- `cd core && uv run business-use scan e2e-tests/js --dry-run` — manual smoke test
+
+Key files:
+- `core/src/scanner/` — scanner module (new)
+- `core/src/cli.py` — CLI entry point (modified: add `scan` command)
+- `core/src/api/api.py` — API endpoints (modified: add batch upsert)
+- `core/src/api/models.py` — API schemas (modified: add scan schema)
+- `core/tests/scanner/` — scanner tests (new)
+- `core/e2e-tests/` — existing fixtures (unchanged)
+
+## What We're NOT Doing
+
+- **Python SDK scanning** — JS/TS only in V1. Python scanning uses same tree-sitter approach but is a separate effort.
+- **CJS `require()` support** — only ES module `import` syntax. POC already skips these correctly.
+- **Watch mode** — `--watch` for re-scanning on file changes is a V2 feature.
+- **Configuration file** (`.business-use/scan.yaml`) — V2. V1 uses CLI flags only.
+- **Content-hash caching** — V2 optimization. V1 does a full scan each time (sub-second for typical projects anyway).
+- **Local DB sync** — scanner only talks to API or dry-runs. No direct DB writes.
+- **Wrapper function detection** — only direct `ensure()`/`act()`/`assert()` calls from `business-use` imports.
+
+## Implementation Approach
+
+1. **Promote POC to production module** — the POC scanner is well-structured and tested. Refactor it into `core/src/scanner/` with proper typing, error handling, and modularity.
+2. **CLI first, API second** — get `--dry-run` working before building the API endpoint. This lets us validate the scanner independently.
+3. **New batch upsert endpoint** — `POST /v1/nodes/scan` that accepts the scanner's output format and upserts nodes with `source="scan"`.
+4. **Reuse existing patterns** — follow the `nodes sync` command pattern for upsert logic, the existing Click CLI patterns for the command, and `httpx` for API calls.
+
+---
+
+## Phase 1: Scanner Module — Promote POC to Production
+
+### Overview
+Move the POC scanner from `core/e2e-tests/poc_scanner.py` into a proper `core/src/scanner/` module with better structure, typing, and test coverage.
+
+### Changes Required:
+
+#### 1. Add tree-sitter dependencies
+**File**: `core/pyproject.toml`
+**Changes**: Add `tree-sitter>=0.25.0`, `tree-sitter-javascript>=0.25.0`, `tree-sitter-typescript>=0.23.0` as optional dependencies under a `[scan]` extra:
+
+```toml
+[project.optional-dependencies]
+scan = [
+    "tree-sitter>=0.25.0",
+    "tree-sitter-javascript>=0.25.0",
+    "tree-sitter-typescript>=0.23.0",
+]
+```
+
+The `scan` command should check for these at runtime and print a helpful install message if missing:
+`pip install business-use-core[scan]` or `uvx --with 'business-use-core[scan]' business-use-core scan ...`
+
+For dev, add them to the dev dependency group so they're always available during development.
+
+#### 1b. Extend `NodeSource` type
+**File**: `core/src/models.py`
+**Changes**: Add `"scan"` to the `NodeSource` literal:
+
+```python
+NodeSource = Literal[
+    "code",
+    "manual",
+    "scan",
+]
+```
+
+No database migration needed — the column is a plain `String` type, not an enum constraint. The `Literal` type is only enforced at the Python level.
+
+#### 1c. Expand `TARGET_MODULES` to include scoped package name
+**File**: `core/src/scanner/imports.py` (when creating from POC)
+**Changes**: The POC's `TARGET_MODULES = {"business-use", "business_use"}` must be expanded to also match the scoped npm package:
+
+```python
+TARGET_MODULES = {"business-use", "business_use", "@desplega.ai/business-use"}
+```
+
+This ensures the scanner works with real-world imports (`import { ensure } from '@desplega.ai/business-use'`), not just the shorthand used in test fixtures.
+
+#### 2. Create scanner module structure
+```
+core/src/scanner/
+├── __init__.py          # Public API: scan_files(), scan_directory()
+├── parser.py            # Tree-sitter parsing: language detection, AST walking
+├── extractor.py         # Property extraction from AST nodes
+├── imports.py           # Import analysis: named, aliased, namespace
+├── models.py            # Scanner-specific types (ExtractedNode, ScanResult, ScanWarning)
+└── validator.py         # Graph validation: dep_ids refs, duplicates, unreachable nodes
+```
+
+**`models.py`**: Define scanner output types using dataclasses or TypedDict:
+- `ExtractedNode`: id, flow, type, dep_ids, has_validator, has_filter, description, conditions, source (file, line, column), warnings
+- `ScanResult`: version, scanned_at, files_scanned, files_skipped, flows (dict of flow → list of ExtractedNode), warnings
+- `ScanWarning`: file, line, message
+
+**`imports.py`**: Extract from POC `extract_imports()` — handles named imports, aliased imports (`import { ensure as track }`), namespace imports (`import * as bu`).
+
+**`parser.py`**: Extract from POC `get_language()`, `get_string_value()`, `_walk()`. Add proper error handling for file read failures.
+
+**`extractor.py`**: Extract from POC `is_target_call()`, `extract_object_props()`, `scan_file()`. Compose imports + parser functions.
+
+**`validator.py`**: New code — graph validation:
+- Check all `dep_ids` reference existing nodes within same flow → warn if not
+- Check for duplicate node IDs within a flow → warn
+- Check for unreachable nodes (no path from root) → warn
+
+**`__init__.py`**: Public API functions:
+- `scan_files(paths: list[Path]) -> ScanResult` — scan specific files
+- `scan_directory(path: Path, include: list[str], exclude: list[str]) -> ScanResult` — scan directory with glob patterns
+- `validate_graph(result: ScanResult) -> list[ScanWarning]` — run graph validation
+
+#### 3. Create scanner tests
+**Directory**: `core/tests/scanner/`
+**Files**:
+- `test_imports.py` — test import detection (named, aliased, namespace, non-business-use)
+- `test_extractor.py` — test node extraction against each e2e fixture
+- `test_validator.py` — test graph validation (broken refs, duplicates, unreachable)
+- `conftest.py` — fixtures pointing to `core/e2e-tests/js/` files
+
+Tests should assert against the known-good POC results documented in the research (e.g., `basic-flow.ts` → 3 nodes, `aliased-import.ts` → 1 node, `no-business-use.ts` → 0 nodes).
+
+### Success Criteria:
+
+#### Automated Verification:
+- [x] Scanner tests pass: `cd core && uv run pytest tests/scanner/ -v`
+- [x] All 9 JS/TS fixtures produce expected results (match POC outputs from research doc)
+- [x] Linting passes: `cd core && uv run ruff check src/scanner/ tests/scanner/`
+- [x] Type checking passes: `cd core && uv run mypy src/scanner/`
+- [x] Dependencies install cleanly: `cd core && uv sync`
+
+#### Manual Verification:
+- [x] `uv run python -c "from src.scanner import scan_directory; print(scan_directory('e2e-tests/js'))"` produces valid output
+- [x] Validator catches broken dep_ids reference (e.g., a node referencing non-existent dep)
+- [x] No-import files are skipped correctly
+- [x] Edge cases produce appropriate warnings (dynamic values, spreads)
+
+**Implementation Note**: After completing this phase, pause for manual confirmation. Create commit after verification passes.
+
+---
+
+## Phase 2: CLI Command — `business-use scan`
+
+### Overview
+Add the `scan` command to the CLI with `--dry-run`, `--format`, `--validate`, and `--flow` flags. No backend connection yet — this phase is purely local.
+
+### Changes Required:
+
+#### 1. Add `scan` command to CLI
+**File**: `core/src/cli.py`
+**Changes**: Add a new top-level `@cli.command()` named `scan` with these options:
+
+```python
+@cli.command()
+@click.argument("path", type=click.Path(exists=True, path_type=Path))
+@click.option("--dry-run", is_flag=True, help="Scan and print results without pushing to backend")
+@click.option("--format", "output_format", type=click.Choice(["json", "table"]), default="json", help="Output format for dry-run")
+@click.option("--validate", is_flag=True, help="Run graph validation checks")
+@click.option("--flow", "flow_filter", help="Filter results to a specific flow")
+@click.option("--url", envvar="BUSINESS_USE_URL", help="Backend API URL")
+@click.option("--api-key", envvar="BUSINESS_USE_API_KEY", help="Backend API key")
+def scan(path, dry_run, output_format, validate, flow_filter, url, api_key):
+```
+
+**Behavior**:
+- If `--dry-run`: scan and print results (JSON or table), exit. No `--url`/`--api-key` needed.
+- If `--validate`: run graph validation, print warnings, exit with code 0 (warnings are informational, not errors). Can combine with `--dry-run`.
+- If neither `--dry-run` nor `--validate`: require `--url` and `--api-key` (or env vars), scan, then push to API (Phase 4 will implement the push).
+- If `--flow`: filter results to only include the specified flow.
+- `--format` only applies to `--dry-run` output. Ignored when pushing to API (API push always prints a summary line).
+
+#### 2. Table output formatter
+**File**: `core/src/scanner/formatters.py` (new)
+**Changes**: Implement `format_table(result: ScanResult) -> str` that renders a human-readable table:
+
+```
+Flow: checkout (3 nodes)
+┌──────────────────────┬────────┬─────────────────┬──────────────────────────┐
+│ ID                   │ Type   │ Dep IDs         │ Source                   │
+├──────────────────────┼────────┼─────────────────┼──────────────────────────┤
+│ cart_created         │ act    │ —               │ src/cart/service.ts:42   │
+│ payment_processed    │ assert │ cart_created     │ src/payment/handler.ts:1 │
+│ order_total_matches  │ assert │ cart_created     │ src/cart/service.ts:58   │
+└──────────────────────┴────────┴─────────────────┴──────────────────────────┘
+
+Warnings (2):
+  ⚠ src/utils/helper.ts:22 - ensure() call with non-literal 'id' argument, skipped
+  ⚠ src/edge-cases.ts:15 - depIds contains variable 'extraDep'
+```
+
+Also implement `format_json(result: ScanResult) -> str` — serialize ScanResult to JSON.
+
+#### 3. Create formatter tests
+**File**: `core/tests/scanner/test_formatters.py` (new)
+**Changes**: Test JSON and table output formatting:
+- JSON output matches expected schema (version, scanned_at, files_scanned, flows, warnings)
+- Table output contains expected columns and node data
+- Empty result formatting (no flows found)
+- Flow filter applied before formatting
+
+### Success Criteria:
+
+#### Automated Verification:
+- [x] Help text works: `cd core && uv run business-use scan --help`
+- [x] Dry-run JSON output: `cd core && uv run business-use scan e2e-tests/js --dry-run`
+- [x] Dry-run table output: `cd core && uv run business-use scan e2e-tests/js --dry-run --format table`
+- [x] Validate mode: `cd core && uv run business-use scan e2e-tests/js --validate`
+- [x] Flow filter: `cd core && uv run business-use scan e2e-tests/js --dry-run --flow checkout`
+- [x] Linting passes: `cd core && uv run ruff check src/scanner/ src/cli.py`
+- [x] Type checking passes: `cd core && uv run mypy src/scanner/`
+
+#### Manual Verification:
+- [x] JSON output matches the spec format from the research doc (version, scanned_at, files_scanned, flows, warnings)
+- [x] Table output is readable and properly aligned
+- [x] `--flow` filter correctly includes only matching flow nodes
+- [x] `--validate` prints warnings for broken dep_ids references
+- [x] Running without `--dry-run` or `--url` shows a clear error message asking for either `--dry-run` or `--url`
+- [x] Environment variables `BUSINESS_USE_URL` and `BUSINESS_USE_API_KEY` are picked up correctly
+
+**Implementation Note**: After completing this phase, pause for manual confirmation. Create commit after verification passes.
+
+### QA Spec (optional):
+
+**Approach:** cli-verification
+**Test Scenarios:**
+- [x] TC-1: Dry-run scan of fixture directory
+  - Steps: `cd core && uv run business-use scan e2e-tests/js --dry-run`
+  - Expected: JSON output with 7 files producing nodes, 2 skipped (no-business-use.ts, require-pattern.js), correct node counts per flow
+- [x] TC-2: Validate catches broken references
+  - Steps: Create a temp fixture with `depIds: ["nonexistent"]`, run `--validate`
+  - Expected: Warning about unresolved dep_id reference
+
+---
+
+## Phase 3: Backend Batch Upsert API Endpoint
+
+### Overview
+Create `POST /v1/nodes/scan` — a batch endpoint that accepts the scanner's output format and upserts nodes with `source="scan"`. This is distinct from the existing `POST /v1/nodes` which is for manual creation.
+
+### Changes Required:
+
+#### 1. Add scanner-specific API schema
+**File**: `core/src/api/models.py`
+**Changes**: Add new Pydantic models:
+
+```python
+class ScannedNode(BaseModel):
+    """A node extracted by the scanner."""
+    id: str
+    flow: str
+    type: Literal["act", "assert"]
+    dep_ids: list[str] = []
+    description: str | None = None
+    conditions: list[NodeCondition] = []
+    has_filter: bool = False
+    has_validator: bool = False
+    source_file: str | None = None
+    source_line: int | None = None
+    source_column: int | None = None
+
+class ScanUploadPayload(BaseModel):
+    """Payload from the scanner CLI."""
+    version: str = "1.0"
+    scanned_at: str
+    files_scanned: int
+    flows: dict[str, list[ScannedNode]]
+```
+
+#### 2. Add batch upsert endpoint
+**File**: `core/src/api/api.py`
+**Changes**: Add `POST /v1/nodes/scan` endpoint:
+
+- Accepts `ScanUploadPayload`
+- For each node in each flow:
+  - Check if node exists (by `id`)
+  - If exists: update fields, set `source="scan"`, set `updated_at=now()`, clear `deleted_at`
+  - If not: create with `source="scan"`, `created_at=now()`
+- Soft-delete nodes that were previously `source="scan"` in the same flow but are no longer present in the payload (stale node cleanup — required to prevent ghost nodes from deleted SDK calls)
+- Return summary: `{ created: N, updated: N, deleted: N, flows: [...] }`
+
+#### 3. Add tests for the endpoint
+**File**: `core/tests/api/test_scan_endpoint.py` (new)
+**Changes**: Test the batch upsert endpoint:
+- Create nodes → verify created
+- Update nodes (re-scan with changed properties) → verify updated
+- Stale node cleanup (node in DB but not in scan payload) → verify soft-deleted
+- Auth required (no API key → 401)
+
+### Success Criteria:
+
+#### Automated Verification:
+- [x] API tests pass: `cd core && uv run pytest tests/api/test_scan_endpoint.py -v`
+- [x] Existing API tests still pass: `cd core && uv run pytest tests/ -v`
+- [x] Linting passes: `cd core && uv run ruff check src/api/`
+- [x] Type checking passes: `cd core && uv run mypy src/api/`
+
+#### Manual Verification:
+- [ ] Start server: `cd core && uv run business-use server dev`
+- [ ] POST scan payload via curl:
+  ```bash
+  curl -X POST http://localhost:13370/v1/nodes/scan \
+    -H "X-Api-Key: <key>" \
+    -H "Content-Type: application/json" \
+    -d '{"version":"1.0","scanned_at":"2026-03-25T10:00:00Z","files_scanned":1,"flows":{"checkout":[{"id":"cart_created","flow":"checkout","type":"act","dep_ids":[]}]}}'
+  ```
+- [ ] Verify node appears in `GET /v1/nodes` with `source="scan"`
+- [ ] Re-POST same payload with changed description → verify node updated
+- [ ] Verify existing manual/code nodes are NOT affected by scan upsert
+
+**Implementation Note**: After completing this phase, pause for manual confirmation. Create commit after verification passes.
+
+---
+
+## Phase 4: Wire Scanner CLI to API
+
+### Overview
+Connect the `scan` command to the backend API so that `business-use scan ./src --url ... --api-key ...` pushes extracted nodes to the backend.
+
+### Changes Required:
+
+#### 1. Add API client for scanner
+**File**: `core/src/scanner/api_client.py` (new)
+**Changes**: Implement `push_scan_result(result: ScanResult, url: str, api_key: str) -> dict`:
+- Serialize `ScanResult` to `ScanUploadPayload` JSON
+- POST to `{url}/v1/nodes/scan` with `X-Api-Key` header
+- Handle errors: connection refused, auth failure (401), server error (5xx)
+- Return the API response summary (created/updated/deleted counts)
+- Use `httpx` (already a dependency)
+
+#### 2. Wire CLI to API client
+**File**: `core/src/cli.py` (the `scan` command from Phase 2)
+**Changes**: When not `--dry-run` and not `--validate`:
+- Require `--url` (or `BUSINESS_USE_URL` env var) — exit with error if missing
+- Require `--api-key` (or `BUSINESS_USE_API_KEY` env var) — exit with error if missing
+- Call `push_scan_result()`
+- Print summary: "Pushed N nodes across M flows (created: X, updated: Y)"
+- Exit with code 0 on success, 1 on API error
+
+#### 3. Add API client tests
+**File**: `core/tests/scanner/test_api_client.py` (new)
+**Changes**: Test the API client with mocked httpx responses:
+- Success case
+- Auth failure (401)
+- Connection error
+- Server error (5xx)
+
+### Success Criteria:
+
+#### Automated Verification:
+- [x] API client tests pass: `cd core && uv run pytest tests/scanner/test_api_client.py -v`
+- [x] All scanner tests still pass: `cd core && uv run pytest tests/scanner/ -v`
+- [x] Linting passes: `cd core && uv run ruff check src/scanner/`
+- [x] Type checking passes: `cd core && uv run mypy src/scanner/`
+
+#### Manual Verification:
+- [ ] Start backend: `cd core && uv run business-use server dev`
+- [ ] Run scanner against fixtures: `cd core && uv run business-use scan e2e-tests/js --url http://localhost:13370 --api-key <key>`
+- [ ] Verify output shows "Pushed N nodes across M flows"
+- [ ] Verify nodes appear in backend: `curl http://localhost:13370/v1/nodes -H "X-Api-Key: <key>"`
+- [ ] Run again → verify "updated" count (idempotent upsert)
+- [ ] Test with wrong API key → verify clear error message
+- [ ] Test with wrong URL → verify clear connection error message
+- [ ] Test with env vars: `BUSINESS_USE_URL=... BUSINESS_USE_API_KEY=... business-use scan e2e-tests/js`
+
+**Implementation Note**: After completing this phase, pause for manual confirmation. Create commit after verification passes.
+
+### QA Spec (optional):
+
+**Approach:** cli-verification
+**Test Scenarios:**
+- [ ] TC-1: Full end-to-end scan and push
+  - Steps: Start server, run `business-use scan e2e-tests/js --url http://localhost:13370 --api-key <key>`
+  - Expected: Nodes created in backend, summary printed
+- [ ] TC-2: Idempotent re-scan
+  - Steps: Run same scan command twice
+  - Expected: First run creates, second run updates (no duplicates)
+- [ ] TC-3: CI/CD simulation
+  - Steps: `uvx business-use-core scan e2e-tests/js --url http://localhost:13370 --api-key <key>`
+  - Expected: Works via uvx without local install
+
+---
+
+## Testing Strategy
+
+### Unit Tests (`core/tests/scanner/`)
+- **`test_imports.py`**: Import detection for each import pattern (named, aliased, namespace, non-target)
+- **`test_extractor.py`**: Node extraction against each of the 9 JS/TS fixture files, asserting exact outputs
+- **`test_validator.py`**: Graph validation (broken refs, duplicates, unreachable nodes)
+- **`test_api_client.py`**: API client with mocked HTTP responses
+- **`test_formatters.py`**: JSON and table output formatting
+
+### Integration Tests
+- **`test_scan_endpoint.py`**: API endpoint with real DB (using test database)
+
+### Manual E2E Verification
+```bash
+# 1. Start backend
+cd core && uv run business-use server dev --reload
+
+# 2. Dry-run scan
+uv run business-use scan e2e-tests/js --dry-run
+uv run business-use scan e2e-tests/js --dry-run --format table
+uv run business-use scan e2e-tests/js --dry-run --flow checkout
+
+# 3. Validate
+uv run business-use scan e2e-tests/js --validate
+
+# 4. Push to backend
+uv run business-use scan e2e-tests/js --url http://localhost:13370 --api-key <key>
+
+# 5. Verify nodes in backend
+curl http://localhost:13370/v1/nodes -H "X-Api-Key: <key>" | python -m json.tool
+
+# 6. Re-scan (idempotent)
+uv run business-use scan e2e-tests/js --url http://localhost:13370 --api-key <key>
+
+# 7. CI/CD style (via uvx)
+uvx business-use-core scan e2e-tests/js --dry-run
+```
+
+## References
+- Research: `thoughts/taras/research/2026-03-25-static-analysis-sdk-extraction.md`
+- POC scanner: `core/e2e-tests/poc_scanner.py`
+- E2E fixtures: `core/e2e-tests/js/` (9 files), `core/e2e-tests/py/` (4 files)
+- Node model: `core/src/models.py:154-228`
+- Nodes sync command: `core/src/cli.py:1299-1427`
+- API schemas: `core/src/api/models.py`
+
+---
+
+## Review Errata
+
+_Reviewed: 2026-03-25 by Claude_
+
+### Critical
+- [x] `NodeSource` type (`core/src/models.py:68-71`) only allows `"code"` | `"manual"` — must add `"scan"` before using it as a source value — **fixed: added Phase 1b**
+
+### Important
+- [x] `TARGET_MODULES` in POC (`poc_scanner.py:19`) missing `@desplega.ai/business-use` scoped package name — real user imports would be missed — **fixed: added Phase 1c**
+- [x] Stale node cleanup was marked as "optional" in Phase 3 — required to prevent ghost nodes — **fixed: made required**
+- [x] tree-sitter deps as runtime dependencies adds ~4MB for all users — **fixed: moved to optional `[scan]` extra with runtime check**
+
+### Resolved (Minor)
+- [x] Phase 1 manual verification used `python -c` instead of `uv run python -c` — auto-fixed
+- [x] `test_formatters.py` listed in Testing Strategy but missing from Phase 2 changes — auto-fixed: added as Phase 2 step 3
+- [x] `--format` behavior without `--dry-run` was undefined — auto-fixed: documented as ignored when pushing to API


### PR DESCRIPTION
## Summary

- Adds `business-use scan` CLI command that statically analyzes JS/TS codebases using tree-sitter to extract all `ensure()`, `act()`, `assert()` SDK call sites
- Supports `--dry-run` (json/table output), `--validate` (graph integrity checks), `--flow` (filter by flow), and `--url`/`--api-key` (push to backend)
- Adds `POST /v1/nodes/scan` batch upsert endpoint with stale node soft-deletion
- Scanner handles named, aliased, and namespace imports from `business-use`, `business_use`, and `@desplega.ai/business-use`
- Tree-sitter dependencies are optional (`pip install business-use-core[scan]`) to keep the base package lean

## Test plan

- [x] 191 tests passing (`uv run pytest tests/ -v`)
- [x] 44 scanner unit tests (imports, extractor, validator, formatters, api client)
- [x] 5 endpoint integration tests (create, update, stale cleanup, manual unaffected, 401)
- [x] Lint clean (`ruff check`)
- [x] Format clean (`ruff format --check`)
- [x] CLI smoke tests: `--help`, `--dry-run`, `--dry-run --format table`, `--validate`
- [x] Manual E2E: start server, push scan results, verify in backend